### PR TITLE
Make access token configurable

### DIFF
--- a/packages/next-drupal/src/get-access-token.ts
+++ b/packages/next-drupal/src/get-access-token.ts
@@ -1,8 +1,6 @@
-export async function getAccessToken(): Promise<{
-  token_type: string
-  expires_in: number
-  access_token: string
-}> {
+import { AccessToken } from "./types"
+
+export async function getAccessToken(): Promise<AccessToken> {
   if (!process.env.DRUPAL_CLIENT_ID || !process.env.DRUPAL_CLIENT_SECRET) {
     return null
   }

--- a/packages/next-drupal/src/get-menu.ts
+++ b/packages/next-drupal/src/get-menu.ts
@@ -1,10 +1,15 @@
-import { DrupalMenuLinkContent, JsonApiWithLocaleOptions } from "./types"
-import { buildUrl, deserialize } from "./utils"
+import {
+  AccessToken,
+  DrupalMenuLinkContent,
+  JsonApiWithLocaleOptions,
+} from "./types"
+import { buildHeaders, buildUrl, deserialize } from "./utils"
 
 export async function getMenu(
   name: string,
   options?: {
     deserialize?: boolean
+    accessToken?: AccessToken
   } & JsonApiWithLocaleOptions
 ): Promise<{
   items: DrupalMenuLinkContent[]
@@ -22,7 +27,9 @@ export async function getMenu(
 
   const url = buildUrl(`${localePrefix}/jsonapi/menu_items/${name}`)
 
-  const response = await fetch(url.toString())
+  const response = await fetch(url.toString(), {
+    headers: await buildHeaders(options),
+  })
 
   if (!response.ok) {
     throw new Error(response.statusText)

--- a/packages/next-drupal/src/get-paths.ts
+++ b/packages/next-drupal/src/get-paths.ts
@@ -1,12 +1,13 @@
 import { GetStaticPathsContext } from "next"
 import { getResourceCollection } from "./get-resource-collection"
-import { JsonApiParams, Locale } from "./types"
+import { AccessToken, JsonApiParams, Locale } from "./types"
 
 export async function getPathsFromContext(
   types: string | string[],
   context: GetStaticPathsContext,
   options: {
     params?: JsonApiParams
+    accessToken?: AccessToken
   } = {}
 ) {
   if (typeof types === "string") {

--- a/packages/next-drupal/src/get-resource-collection.ts
+++ b/packages/next-drupal/src/get-resource-collection.ts
@@ -1,5 +1,5 @@
 import { GetStaticPropsContext } from "next"
-import { JsonApiParams, JsonApiWithLocaleOptions } from "./types"
+import { AccessToken, JsonApiParams, JsonApiWithLocaleOptions } from "./types"
 import {
   buildHeaders,
   buildUrl,
@@ -11,6 +11,7 @@ export async function getResourceCollection(
   type: string,
   options?: {
     deserialize?: boolean
+    accessToken?: AccessToken
   } & JsonApiWithLocaleOptions
 ) {
   const apiPath = await getJsonApiPathForResourceType(
@@ -27,7 +28,7 @@ export async function getResourceCollection(
   })
 
   const response = await fetch(url.toString(), {
-    headers: await buildHeaders(),
+    headers: await buildHeaders(options),
   })
 
   if (!response.ok) {

--- a/packages/next-drupal/src/get-resource-type.ts
+++ b/packages/next-drupal/src/get-resource-type.ts
@@ -1,9 +1,11 @@
 import { GetStaticPropsContext } from "next"
+import { AccessToken } from "./types"
 import { buildHeaders, buildUrl, getPathFromContext } from "./utils"
 
 export async function getResourceTypeFromContext(
   context: GetStaticPropsContext,
   options?: {
+    accessToken?: AccessToken
     prefix?: string
   }
 ): Promise<string> {
@@ -16,7 +18,7 @@ export async function getResourceTypeFromContext(
   })
 
   const response = await fetch(url.toString(), {
-    headers: await buildHeaders(),
+    headers: await buildHeaders(options),
   })
 
   if (response.status === 404) {

--- a/packages/next-drupal/src/get-resource.ts
+++ b/packages/next-drupal/src/get-resource.ts
@@ -1,5 +1,5 @@
 import { GetStaticPropsContext } from "next"
-import { JsonApiParams, JsonApiWithLocaleOptions } from "./types"
+import { AccessToken, JsonApiParams, JsonApiWithLocaleOptions } from "./types"
 import {
   buildHeaders,
   buildUrl,
@@ -15,6 +15,7 @@ export async function getResourceFromContext(
     prefix?: string
     deserialize?: boolean
     params?: JsonApiParams
+    accessToken?: AccessToken
   }
 ) {
   options = {
@@ -60,6 +61,7 @@ export async function getResourceFromContext(
 export async function getResourceByPath(
   path: string,
   options?: {
+    accessToken?: AccessToken
     deserialize?: boolean
   } & JsonApiWithLocaleOptions
 ) {
@@ -126,7 +128,7 @@ export async function getResourceByPath(
   const response = await fetch(url.toString(), {
     method: "POST",
     credentials: "include",
-    headers: await buildHeaders(),
+    headers: await buildHeaders(options),
     redirect: "follow",
     body: JSON.stringify(payload),
   })
@@ -154,6 +156,7 @@ export async function getResource(
   type: string,
   uuid: string,
   options?: {
+    accessToken?: AccessToken
     deserialize?: boolean
   } & JsonApiWithLocaleOptions
 ) {
@@ -177,7 +180,7 @@ export async function getResource(
   })
 
   const response = await fetch(url.toString(), {
-    headers: await buildHeaders(),
+    headers: await buildHeaders(options),
   })
 
   if (!response.ok) {

--- a/packages/next-drupal/src/get-view.ts
+++ b/packages/next-drupal/src/get-view.ts
@@ -1,10 +1,11 @@
-import { JsonApiWithLocaleOptions } from "./types"
-import { buildUrl, deserialize } from "./utils"
+import { AccessToken, JsonApiWithLocaleOptions } from "./types"
+import { buildHeaders, buildUrl, deserialize } from "./utils"
 
 export async function getView<T>(
   name: string,
   options?: {
     deserialize?: boolean
+    accessToken?: AccessToken
   } & JsonApiWithLocaleOptions
 ): Promise<{
   results: T
@@ -33,7 +34,9 @@ export async function getView<T>(
     options.params
   )
 
-  const response = await fetch(url.toString())
+  const response = await fetch(url.toString(), {
+    headers: await buildHeaders(options),
+  })
 
   if (!response.ok) {
     throw new Error(response.statusText)

--- a/packages/next-drupal/src/types.ts
+++ b/packages/next-drupal/src/types.ts
@@ -58,3 +58,9 @@ export interface DrupalMenuLinkContent {
   weight: string
   items?: DrupalMenuLinkContent[]
 }
+
+export type AccessToken = {
+  token_type: string
+  expires_in: number
+  access_token: string
+}

--- a/packages/next-drupal/src/utils.ts
+++ b/packages/next-drupal/src/utils.ts
@@ -1,10 +1,9 @@
-import { GetStaticPropsContext } from "next"
 import Jsona from "jsona"
+import { GetStaticPropsContext } from "next"
+import { getAccessToken } from "./get-access-token"
+import { AccessToken, Locale } from "./types"
 
 const JSONAPI_PREFIX = process.env.DRUPAL_JSONAPI_PREFIX || "/jsonapi"
-
-import { getAccessToken } from "./get-access-token"
-import { Locale } from "./types"
 
 const dataFormatter = new Jsona()
 
@@ -24,7 +23,10 @@ export async function getJsonApiPathForResourceType(
 }
 
 export async function getJsonApiIndex(
-  locale?: Locale
+  locale?: Locale,
+  options?: {
+    accessToken?: AccessToken
+  }
 ): Promise<{
   links: {
     [type: string]: {
@@ -37,7 +39,7 @@ export async function getJsonApiIndex(
   )
 
   const response = await fetch(url.toString(), {
-    headers: await buildHeaders(),
+    headers: await buildHeaders(options),
   })
 
   if (!response.ok) {
@@ -64,12 +66,16 @@ export function buildUrl(
   return url
 }
 
-export async function buildHeaders(
-  headers: RequestInit["headers"] = {
+export async function buildHeaders({
+  accessToken,
+  headers = {
     "Content-Type": "application/json",
-  }
-): Promise<RequestInit["headers"]> {
-  const token = await getAccessToken()
+  },
+}: {
+  accessToken?: AccessToken
+  headers?: RequestInit["headers"]
+} = {}): Promise<RequestInit["headers"]> {
+  const token = accessToken || (await getAccessToken())
   if (token) {
     headers["Authorization"] = `Bearer ${token.access_token}`
   }


### PR DESCRIPTION
First of all, awesome work! I'm also using Drupal and Next.js and this module looks really great. 

I'm currently working on a Next.js app with personalized content. I use a different oauth strategy to obtain an access token. I would like te be able to use my own access token in the requests to the json api. 