### PR TITLE
feat(next-drupal): check for redirect

### DIFF
--- a/packages/next-drupal/src/get-resource.ts
+++ b/packages/next-drupal/src/get-resource.ts
@@ -14,6 +14,7 @@ export async function getResourceFromContext(
   options?: {
     prefix?: string
     deserialize?: boolean
+    checkRedirect?: boolean
     params?: JsonApiParams
   }
 ) {
@@ -61,10 +62,12 @@ export async function getResourceByPath(
   path: string,
   options?: {
     deserialize?: boolean
+    checkRedirect?: boolean
   } & JsonApiWithLocaleOptions
 ) {
   options = {
     deserialize: true,
+    checkRedirect: false,
     params: {},
     ...options,
   }
@@ -136,6 +139,19 @@ export async function getResourceByPath(
   }
 
   const json = await response.json()
+
+  if (options.checkRedirect) {
+    const router = JSON.parse(json.router?.body)
+    if (router?.redirect && router?.redirect.length > 0) {
+      const redirect = router.redirect.slice(-1)[0]
+      return {
+        redirect: {
+          destination: redirect.to,
+          statusCode: parseInt(redirect.status),
+        },
+      }
+    }
+  }
 
   if (!json["resolvedResource#uri{0}"]) {
     return null

--- a/www/docs/reference.mdx
+++ b/www/docs/reference.mdx
@@ -141,6 +141,7 @@ function getResourceFromContext(
   options?: {
     prefix?: string
     deserialize?: boolean
+    checkRedirect?: boolean
     params?: JsonApiParams
   }
 ): Promise<any>
@@ -176,6 +177,7 @@ function getResourceByPath(
   path: string,
   options?: {
     deserialize?: boolean
+    checkRedirect?: boolean
   } & JsonApiWithLocaleOptions
 ): Promise<any>
 ```


### PR DESCRIPTION
I would like to (optionally) check for redirects when fetching a resource. The decoupled router response may have information about a redirect for a given path. In that case the decoupled router response contains something like:

```
"redirect": [
  {
    "from": "/old/path",
    "to": "/new/path",
    "status": "301"
  }
]
```

It is possible to fetch and return all redirects in `next.config.js`, but this only works for redirects that are known at build time. 

When using SSG with fallback or SSR, I would like to be able te return a redirect response for redirects that are created in Drupal after build time. 