### PR TITLE
Removed patch for drupal/subrequests

### DIFF
--- a/modules/next/composer.json
+++ b/modules/next/composer.json
@@ -23,7 +23,6 @@
   "extra": {
     "patches": {
       "drupal/subrequests": {
-        "Subrequest failed validation": "https://www.drupal.org/files/issues/2019-05-27/3029570-array-not-object.patch",
         "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
       }
     }


### PR DESCRIPTION
Removed patch for drupal/subrequests "Subrequest failed validation" because it is fixed in subrequests module.