### PR TITLE
Fix wrong package name in password-grant.mdx

### DIFF
--- a/www/docs/authentication/password-grant.mdx
+++ b/www/docs/authentication/password-grant.mdx
@@ -18,10 +18,10 @@ See [https://example-auth.next-drupal.org/](https://example-auth.next-drupal.org
 
 ## Dependencies
 
-Add `next-auth` and `jwt_decode` to your Next.js site.
+Add `next-auth` and `jwt-decode` to your Next.js site.
 
 ```sh
-yarn add next-auth@beta jwt_decode
+yarn add next-auth@beta jwt-decode
 ```
 
 <Callout>


### PR DESCRIPTION
I was going through the authentication example and found that the npm package is named jwt-decode not jwt_decode. Trying to install jwt_decode will result in an error.

After that everything is working.