### PR TITLE
feat(next-drupal): allow using a custom fetch implementation

### DIFF
--- a/packages/next-drupal/src/get-access-token.ts
+++ b/packages/next-drupal/src/get-access-token.ts
@@ -1,9 +1,11 @@
 import { cache } from "./get-cache"
-import { AccessToken } from "./types"
+import { AccessToken, FetchAPI } from "./types"
 
 const CACHE_KEY = "NEXT_DRUPAL_ACCESS_TOKEN"
 
-export async function getAccessToken(): Promise<AccessToken> {
+export async function getAccessToken(options?: {
+  fetch?: FetchAPI
+}): Promise<AccessToken> {
   if (!process.env.DRUPAL_CLIENT_ID || !process.env.DRUPAL_CLIENT_SECRET) {
     return null
   }
@@ -13,11 +15,13 @@ export async function getAccessToken(): Promise<AccessToken> {
     return cached
   }
 
+  options = { fetch, ...options }
+
   const basic = Buffer.from(
     `${process.env.DRUPAL_CLIENT_ID}:${process.env.DRUPAL_CLIENT_SECRET}`
   ).toString("base64")
 
-  const response = await fetch(
+  const response = await options.fetch(
     `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/oauth/token`,
     {
       method: "POST",

--- a/packages/next-drupal/src/get-menu.ts
+++ b/packages/next-drupal/src/get-menu.ts
@@ -1,6 +1,7 @@
 import {
   AccessToken,
   DrupalMenuLinkContent,
+  FetchAPI,
   JsonApiWithLocaleOptions,
 } from "./types"
 import { buildHeaders, buildUrl, deserialize } from "./utils"
@@ -10,6 +11,7 @@ export async function getMenu(
   options?: {
     deserialize?: boolean
     accessToken?: AccessToken
+    fetch?: FetchAPI
   } & JsonApiWithLocaleOptions
 ): Promise<{
   items: DrupalMenuLinkContent[]
@@ -17,6 +19,7 @@ export async function getMenu(
 }> {
   options = {
     deserialize: true,
+    fetch,
     ...options,
   }
 
@@ -27,7 +30,7 @@ export async function getMenu(
 
   const url = buildUrl(`${localePrefix}/jsonapi/menu_items/${name}`)
 
-  const response = await fetch(url.toString(), {
+  const response = await options.fetch(url.toString(), {
     headers: await buildHeaders(options),
   })
 

--- a/packages/next-drupal/src/get-paths.ts
+++ b/packages/next-drupal/src/get-paths.ts
@@ -1,15 +1,18 @@
 import { GetStaticPathsContext, GetStaticPathsResult } from "next"
 import { getResourceCollection } from "./get-resource-collection"
-import { AccessToken, JsonApiParams, Locale } from "./types"
+import { AccessToken, FetchAPI, JsonApiParams, Locale } from "./types"
 
 export async function getPathsFromContext(
   types: string | string[],
   context: GetStaticPathsContext,
-  options: {
+  options?: {
     params?: JsonApiParams
     accessToken?: AccessToken
-  } = {}
+    fetch?: FetchAPI
+  }
 ): Promise<GetStaticPathsResult["paths"]> {
+  options = { fetch, ...options }
+
   if (typeof types === "string") {
     types = [types]
   }

--- a/packages/next-drupal/src/get-resource-collection.ts
+++ b/packages/next-drupal/src/get-resource-collection.ts
@@ -4,6 +4,7 @@ import {
   JsonApiParams,
   JsonApiWithLocaleOptions,
   JsonApiResource,
+  FetchAPI,
 } from "./types"
 import {
   buildHeaders,
@@ -17,10 +18,12 @@ export async function getResourceCollection<T = JsonApiResource[]>(
   options?: {
     deserialize?: boolean
     accessToken?: AccessToken
+    fetch?: FetchAPI
   } & JsonApiWithLocaleOptions
 ): Promise<T> {
   options = {
     deserialize: true,
+    fetch,
     ...options,
   }
 
@@ -37,7 +40,7 @@ export async function getResourceCollection<T = JsonApiResource[]>(
     ...options?.params,
   })
 
-  const response = await fetch(url.toString(), {
+  const response = await options.fetch(url.toString(), {
     headers: await buildHeaders(options),
   })
 
@@ -56,10 +59,12 @@ export async function getResourceCollectionFromContext<T = JsonApiResource[]>(
   options?: {
     deserialize?: boolean
     params?: JsonApiParams
+    fetch?: FetchAPI
   }
 ): Promise<T> {
   options = {
     deserialize: true,
+    fetch,
     ...options,
   }
 

--- a/packages/next-drupal/src/get-resource-type.ts
+++ b/packages/next-drupal/src/get-resource-type.ts
@@ -1,5 +1,5 @@
 import { GetStaticPropsContext } from "next"
-import { AccessToken } from "./types"
+import { AccessToken, FetchAPI } from "./types"
 import { buildHeaders, buildUrl, getPathFromContext } from "./utils"
 
 export async function getResourceTypeFromContext(
@@ -7,17 +7,19 @@ export async function getResourceTypeFromContext(
   options?: {
     accessToken?: AccessToken
     prefix?: string
+    fetch?: FetchAPI
   }
 ): Promise<string> {
   options = {
     prefix: "",
+    fetch,
     ...options,
   }
   const url = buildUrl("/router/translate-path", {
     path: getPathFromContext(context, options.prefix),
   })
 
-  const response = await fetch(url.toString(), {
+  const response = await options.fetch(url.toString(), {
     headers: await buildHeaders(options),
   })
 

--- a/packages/next-drupal/src/get-search-index.ts
+++ b/packages/next-drupal/src/get-search-index.ts
@@ -1,4 +1,5 @@
 import { GetStaticPropsContext } from "next"
+import { FetchAPI } from "."
 import { AccessToken, JsonApiResource, JsonApiWithLocaleOptions } from "./types"
 import { buildHeaders, buildUrl, deserialize } from "./utils"
 
@@ -7,10 +8,12 @@ export async function getSearchIndex<T = JsonApiResource[]>(
   options?: {
     deserialize?: boolean
     accessToken?: AccessToken
+    fetch?: FetchAPI
   } & JsonApiWithLocaleOptions
 ): Promise<T> {
   options = {
     deserialize: true,
+    fetch,
     ...options,
   }
 
@@ -21,7 +24,7 @@ export async function getSearchIndex<T = JsonApiResource[]>(
 
   const url = buildUrl(`${localePrefix}/jsonapi/index/${name}`, options.params)
 
-  const response = await fetch(url.toString(), {
+  const response = await options.fetch(url.toString(), {
     headers: await buildHeaders(options),
   })
 
@@ -40,6 +43,7 @@ export async function getSearchIndexFromContext<T = JsonApiResource[]>(
   options?: {
     deserialize?: boolean
     accessToken?: AccessToken
+    fetch?: FetchAPI
   } & JsonApiWithLocaleOptions
 ): Promise<T> {
   options = {

--- a/packages/next-drupal/src/get-view.ts
+++ b/packages/next-drupal/src/get-view.ts
@@ -1,4 +1,4 @@
-import { AccessToken, JsonApiWithLocaleOptions } from "./types"
+import { AccessToken, FetchAPI, JsonApiWithLocaleOptions } from "./types"
 import { buildHeaders, buildUrl, deserialize } from "./utils"
 
 export async function getView<T>(
@@ -6,6 +6,7 @@ export async function getView<T>(
   options?: {
     deserialize?: boolean
     accessToken?: AccessToken
+    fetch?: FetchAPI
   } & JsonApiWithLocaleOptions
 ): Promise<{
   results: T
@@ -19,6 +20,7 @@ export async function getView<T>(
 }> {
   options = {
     deserialize: true,
+    fetch,
     ...options,
   }
 
@@ -34,7 +36,7 @@ export async function getView<T>(
     options.params
   )
 
-  const response = await fetch(url.toString(), {
+  const response = await options.fetch(url.toString(), {
     headers: await buildHeaders(options),
   })
 

--- a/packages/next-drupal/src/preview.ts
+++ b/packages/next-drupal/src/preview.ts
@@ -1,12 +1,13 @@
 import { NextApiRequest, NextApiResponse } from "next"
 import { getResourceByPath } from "./get-resource"
-import { JsonApiWithLocaleOptions } from "./types"
+import { JsonApiWithLocaleOptions, FetchAPI } from "./types"
 
 interface PreviewOptions {
   errorMessages?: {
     secret?: string
     slug?: string
   }
+  fetch?: FetchAPI
 }
 
 export function DrupalPreview(options?: PreviewOptions) {
@@ -34,6 +35,7 @@ export async function PreviewHandler(
 
   let _options: GetResourcePreviewUrlOptions = {
     isVersionable: typeof resourceVersion !== "undefined",
+    fetch: options.fetch ?? fetch,
   }
   if (locale && defaultLocale) {
     _options = {
@@ -62,6 +64,7 @@ export async function PreviewHandler(
 
 type GetResourcePreviewUrlOptions = JsonApiWithLocaleOptions & {
   isVersionable?: boolean
+  fetch?: FetchAPI
 }
 
 export async function getResourcePreviewUrl(

--- a/packages/next-drupal/src/types.ts
+++ b/packages/next-drupal/src/types.ts
@@ -162,3 +162,5 @@ export interface DrupalUser extends JsonApiResource {
   name: string
   path: PathAlias
 }
+
+export type FetchAPI = WindowOrWorkerGlobalScope["fetch"]

--- a/packages/next-drupal/src/use-menu.tsx
+++ b/packages/next-drupal/src/use-menu.tsx
@@ -2,10 +2,13 @@ import * as React from "react"
 import { useRouter } from "next/router"
 
 import { getMenu } from "./get-menu"
-import { DrupalMenuLinkContent } from "./types"
+import { DrupalMenuLinkContent, FetchAPI } from "./types"
 
 export function useMenu(
-  name: string
+  name: string,
+  options: {
+    fetch?: FetchAPI
+  }
 ): {
   items: DrupalMenuLinkContent[]
   tree: DrupalMenuLinkContent[]
@@ -25,6 +28,7 @@ export function useMenu(
       setIsLoading(true)
       try {
         const data = await getMenu(name, {
+          ...options,
           locale: router.locale,
           defaultLocale: router.defaultLocale,
         })


### PR DESCRIPTION
Long story short; we needed to collect the cache headers from JSON:API requests. This PR adds the option of passing a custom fetch implementation to be used instead of the global fetch.

I doubt this could be useful for anyone else, since our setup is quite unusual, but I figured I'd create a PR and let you decide. 