### PR TITLE
feat(next): next cache invalidator service

### DIFF
--- a/modules/next/modules/next_extras/next_extras.module
+++ b/modules/next/modules/next_extras/next_extras.module
@@ -73,49 +73,5 @@ function next_extras_form_next_entity_type_config_edit_form_builder($entity_type
  * Implements hook_entity_update().
  */
 function next_extras_entity_update(EntityInterface $entity) {
-  /** @var \Drupal\next\NextEntityTypeManagerInterface $next_entity_type_manager */
-  $next_entity_type_manager = \Drupal::service('next.entity_type.manager');
-
-  $next_entity_type_config = $next_entity_type_manager->getConfigForEntityType($entity->getEntityTypeId(), $entity->bundle());
-  if (!$next_entity_type_config) {
-    return;
-  }
-
-  $revalidate = (bool) $next_entity_type_config->getThirdPartySetting('next_extras', 'revalidate');
-  if (!$revalidate) {
-    return;
-  }
-
-  // Find Next.js sites for entity.
-  $sites = $next_entity_type_config->getSiteResolver()->getSitesForEntity($entity);
-  if (!count($sites)) {
-    return;
-  }
-
-  // Revalidate entity.
-  $slug = $entity->toUrl()->toString();
-
-  foreach ($sites as $site) {
-    $query = [
-      'secret' => $site->getPreviewSecret(),
-      'slug' => $slug,
-    ];
-
-    // TODO: Make this path configurable.
-    $revalidate_url = Url::fromUri("{$site->getBaseUrl()}/api/revalidate", [
-      'query' => $query,
-    ])->toString();
-
-    try {
-      Drupal::logger('next_extras')->notice('Revalidating page at %url', [
-        '%url' => $revalidate_url,
-      ]);
-
-      \Drupal::httpClient()->get($revalidate_url);
-    }
-    catch (RequestException $exception) {
-      watchdog_exception('next_extras', $exception);
-    }
-  }
-
+  \Drupal::service('next_extras.cache_invalidator')->invalidateEntity($entity);
 }

--- a/modules/next/modules/next_extras/next_extras.services.yml
+++ b/modules/next/modules/next_extras/next_extras.services.yml
@@ -1,0 +1,7 @@
+services:
+  next_extras.cache_invalidator:
+    class: Drupal\next_extras\NextCacheInvalidator
+    arguments: ['@next.entity_type.manager', '@http_client', '@logger.channel.next_extras']
+  logger.channel.next_extras:
+    parent: logger.channel_base
+    arguments: [ 'next_extras' ]

--- a/modules/next/modules/next_extras/src/NextCacheInvalidator.php
+++ b/modules/next/modules/next_extras/src/NextCacheInvalidator.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\next_extras;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Url;
+use Drupal\next\Entity\NextSiteInterface;
+use Drupal\next\NextEntityTypeManagerInterface;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * Invalidates Next.js ISR caches.
+ */
+class NextCacheInvalidator {
+
+  /**
+   * Next entity type manager service.
+   *
+   * @var \Drupal\next\NextEntityTypeManagerInterface
+   */
+  private NextEntityTypeManagerInterface $nextEntityTypeManager;
+
+  /**
+   * HTTP client service.
+   *
+   * @var \GuzzleHttp\Client
+   */
+  private Client $httpClient;
+
+  /**
+   * Logger channel.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  private LoggerChannelInterface $logger;
+
+  /**
+   * NextCacheInvalidator constructor.
+   *
+   * @param \Drupal\next\NextEntityTypeManagerInterface $nextEntityTypeManager
+   *   Next entity type manager service.
+   * @param \GuzzleHttp\Client $httpClient
+   *   HTTP client service.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   Logger channel.
+   */
+  public function __construct(NextEntityTypeManagerInterface $nextEntityTypeManager, Client $httpClient, LoggerChannelInterface $logger) {
+    $this->nextEntityTypeManager = $nextEntityTypeManager;
+    $this->httpClient = $httpClient;
+    $this->logger = $logger;
+  }
+
+  /**
+   * Invalidates an entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to invalidate.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function invalidateEntity(EntityInterface $entity): void {
+    $next_entity_type_config = $this->nextEntityTypeManager->getConfigForEntityType($entity->getEntityTypeId(), $entity->bundle());
+    if (!$next_entity_type_config) {
+      return;
+    }
+
+    $revalidate = (bool) $next_entity_type_config->getThirdPartySetting('next_extras', 'revalidate');
+    if (!$revalidate) {
+      return;
+    }
+
+    // Find Next.js sites for entity.
+    $sites = $next_entity_type_config->getSiteResolver()->getSitesForEntity($entity);
+    if (!count($sites)) {
+      return;
+    }
+
+    // Revalidate entity.
+    $slug = $entity->toUrl()->toString();
+    $this->invalidatePath($slug, $sites);
+  }
+
+  /**
+   * Invalidates a path.
+   *
+   * @param string $path
+   *   The path.
+   * @param \Drupal\next\Entity\NextSiteInterface[] $sites
+   *   The site for which to revalidate.
+   */
+  public function invalidatePath(string $path, array $sites): void {
+    foreach ($sites as $site) {
+      $revalidate_url = static::buildUrl($site, $path);
+      try {
+        $this->logger->notice('Revalidating page at %url', [
+          '%url' => $revalidate_url,
+        ]);
+
+        $this->httpClient->get($revalidate_url);
+      }
+      catch (RequestException $exception) {
+        watchdog_exception('next_extras', $exception);
+      }
+    }
+  }
+
+  /**
+   * Builds the invalidation request URL.
+   *
+   * @param \Drupal\next\Entity\NextSiteInterface $site
+   *   The Next site.
+   * @param string $path
+   *   The path.
+   *
+   * @return string
+   *   Built URL.
+   */
+  protected static function buildUrl(NextSiteInterface $site, string $path): string {
+    // @todo Make this path configurable.
+    return Url::fromUri("{$site->getBaseUrl()}/api/revalidate", [
+      'query' => [
+        'secret' => $site->getPreviewSecret(),
+        'slug' => $path,
+      ],
+    ])->toString();
+  }
+
+}


### PR DESCRIPTION
Moves the code invoked in `hook_entity_update` in next_extras to a service. Also adds a method to invalidate a path directly. This is useful if you are defining a page in Next.js that has data fetching methods without being tied to an entity.