### PR TITLE
fix(next): show overridden config on environment variables page

### DIFF
--- a/modules/next/src/Routing/NextSiteHtmlRouteProvider.php
+++ b/modules/next/src/Routing/NextSiteHtmlRouteProvider.php
@@ -44,6 +44,11 @@ class NextSiteHtmlRouteProvider extends AdminHtmlRouteProvider {
     $route->setDefault('_title', 'Environment variables');
     $route->setRequirement('_permission', $entity_type->getAdminPermission());
     $route->setOption('_admin_route', TRUE);
+    $route->setOption('parameters', [
+      'next_site' => [
+        'with_config_overrides' => TRUE,
+      ],
+    ]);
 
     return $route;
   }

--- a/modules/next/tests/src/Kernel/Controller/NextSiteEntityControllerTest.php
+++ b/modules/next/tests/src/Kernel/Controller/NextSiteEntityControllerTest.php
@@ -57,4 +57,17 @@ class NextSiteEntityControllerTest extends KernelTestBase {
     $this->assertEquals(\Drupal::configFactory()->get('system.site')->get('page.front'), $build['container']['DRUPAL_FRONT_PAGE']['#context']['value']);
   }
 
+  /**
+   * @covers ::environmentVariables
+   */
+  public function testOverriddenEnvironmentVariables() {
+    $GLOBALS['config']['next.next_site.' . $this->nextSite->id()] = [
+      'preview_secret' => 'overridden'
+    ];
+    $overridden_entity = NextSite::load($this->nextSite->id());
+    $controller = NextSiteEntityController::create($this->container);
+    $build = $controller->environmentVariables($overridden_entity);
+    $this->assertEquals('overridden', $build['container']['DRUPAL_PREVIEW_SECRET']['#context']['value']);
+  }
+
 }


### PR DESCRIPTION
The environment variables page does not show config overridden via settings.php even though this config is used in the controller.

This is useful for multi-env setups where for example the base URL might differ (local, staging, prod) or if you don't want your preview secret in config.