### PR TITLE
fix(next-drupal): handle cases where menu might be empty

### DIFF
--- a/packages/next-drupal/src/get-menu.ts
+++ b/packages/next-drupal/src/get-menu.ts
@@ -51,6 +51,12 @@ function buildMenuTree(
   links: DrupalMenuLinkContent[],
   parent: DrupalMenuLinkContent["id"] = ""
 ) {
+  if (!links?.length) {
+    return {
+      items: [],
+    }
+  }
+
   const children = links.filter((link) => link.parent === parent)
 
   return children.length


### PR DESCRIPTION
This fixes an issue where a menu might be empty. We want to return an empty array that can be serialized via props.