### PR TITLE
#131 Make the main_content_renderer a service

### DIFF
--- a/modules/next/next.services.yml
+++ b/modules/next/next.services.yml
@@ -8,8 +8,9 @@ services:
   next.entity_type.manager:
     class: Drupal\next\NextEntityTypeManager
     arguments: ["@entity_type.manager"]
-  main_content_renderer.html:
+  next.main_content_renderer.html:
     class: Drupal\next\Render\MainContent\HtmlRenderer
+    decorates: main_content_renderer.html
     arguments:
       [
         "@title_resolver",


### PR DESCRIPTION
Improve the way the `main_content_renderer.html` service is defined by decorating the base one instead of replacing it entirely.