### PR TITLE
feat(next-drupal): introduce throwJsonApiErrors option

### DIFF
--- a/packages/next-drupal/src/types.ts
+++ b/packages/next-drupal/src/types.ts
@@ -67,6 +67,17 @@ export type Experiment_DrupalClientOptions = {
    * [Documentation](https://next-drupal.org/docs/client/configuration#cache)
    */
   cache?: DataCache
+
+  /**
+   * If set to true, JSON:API errors are thrown in non-production environments. The errors are shown in the Next.js overlay.
+   *
+   * **Default value**: `true`
+   * **Required**: *No*
+   *
+   * [Documentation](https://next-drupal.org/docs/client/configuration#throwjsonapierrors)
+   */
+  throwJsonApiErrors?: boolean
+
   /**
    * Override the default logger. You can use this to send logs to a third-party service.
    *


### PR DESCRIPTION
This PR introduces a `throwJsonApiErrors` client options.

- When set to true, `throwJsonApiErrors` will throw errors which are shown in the Next.js overlay.
- This is set to true by default in non-production environments.
- In production, all errors are logged to the console and never thrown.

```ts
const drupal = new DrupalClient("https://example.com", {
  throwJsonApiErrors: false,
})
```