### PR TITLE
fix: Warning title element received an array with more than 1 element

### DIFF
--- a/examples/example-blog/components/meta.tsx
+++ b/examples/example-blog/components/meta.tsx
@@ -35,7 +35,7 @@ export function Meta({ title, tags }: MetaProps) {
         })
       ) : (
         <>
-          <title>{title} | Next.js for Drupal</title>
+          <title>{`${title} | Next.js for Drupal`}</title>
           <meta
             name="description"
             content="A Next.js blog powered by a Drupal backend."

--- a/examples/example-marketing/components/meta.tsx
+++ b/examples/example-marketing/components/meta.tsx
@@ -35,7 +35,7 @@ export function Meta({ title, tags }: MetaProps) {
         })
       ) : (
         <>
-          <title>{title} | Next.js for Drupal</title>
+          <title>{`${title} | Next.js for Drupal`}</title>
           <meta
             name="description"
             content="A Next.js blog powered by a Drupal backend."

--- a/examples/example-umami/components/meta.tsx
+++ b/examples/example-umami/components/meta.tsx
@@ -20,7 +20,7 @@ export function Meta({ title, description }: MetaProps) {
         href={absoluteURL(router.asPath !== "/" ? router.asPath : "")}
       />
       <title>
-        {title} | {siteConfig.name}
+        {`${title} | ${siteConfig.name}`}
       </title>
       <meta name="description" content={description || siteConfig.slogan} />
       <meta


### PR DESCRIPTION
This will fix the following warning:

> Warning: A title element received an array with more than 1 element as children. In browsers title Elements can only have Text Nodes as children. If the children being rendered output more than a single text node in aggregate the browser will display markup and comments as text in the title and hydration will likely fail and fall back to client rendering

This is caused by subtle differences between how React renders elements and nodes.
