### PR TITLE
[docs] Note that "Standard" profile should be selected, add pointer to Umami demo

### DIFF
--- a/www/content/tutorials/quick-start/install-drupal.mdx
+++ b/www/content/tutorials/quick-start/install-drupal.mdx
@@ -21,7 +21,9 @@ Start by creating a new Drupal site using composer.
 composer create-project drupal/recommended-project drupal-site
 ```
 
-Once this is done, you can open the site and proceed with installation.
+Once this is done, you can open the site and proceed with installation, using the "Standard" profile.
+
+If you want to install with the Umami demo experience instead, please see the <a href="/guides/umami-demo">Umami Demo Guide</a>.
 
 ---
 


### PR DESCRIPTION
I ended up running into issue #275 trying to follow along with the [Quick Start guide](https://next-drupal.org/learn/quick-start). This is because the instructions there didn't specify that Standard is required, and what I *actually* wanted to do was install Umami instead.

@shadcn got me sorted lickety-split (thank you!) BUT how about let's improve the docs here so the next person who tries this doesn't hit the same problem. :)