### PR TITLE
feat(next): allow max size to be set via page limit

### DIFF
--- a/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
+++ b/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
@@ -68,7 +68,7 @@ class EntityResource extends JsonApiEntityResource {
    */
   protected function getJsonApiParams(Request $request, ResourceType $resource_type) {
     $params = parent::getJsonApiParams($request, $resource_type);
-    if (!$request->query->has('fields') || $request->query->has('page')) {
+    if (!$request->query->has('fields')) {
       return $params;
     }
 
@@ -84,9 +84,22 @@ class EntityResource extends JsonApiEntityResource {
       return $params;
     }
 
-    if ($sparse_fieldset[$resource_type->getTypeName()][0] === 'path') {
-      $params[OffsetPage::KEY_NAME] = new OffsetPage(OffsetPage::DEFAULT_OFFSET, $this->maxSize);
+    // We expect the first field to be path.
+    // This is spec-compatible.
+    if ($sparse_fieldset[$resource_type->getTypeName()][0] !== 'path') {
+      return $params;
     }
+
+    // Default to parameters.next_jsonapi.size_max.
+    $max = $this->maxSize;
+
+    // Fallback to page[limit] if set.
+    if (($page = $request->query->get('page')) && isset($page['limit'])) {
+      $max = $page['limit'];
+    }
+
+    $params[OffsetPage::KEY_NAME] = new OffsetPage(OffsetPage::DEFAULT_OFFSET, $max);
+
     return $params;
   }
 

--- a/modules/next/modules/next_jsonapi/tests/src/Kernel/Controller/EntityResourceTest.php
+++ b/modules/next/modules/next_jsonapi/tests/src/Kernel/Controller/EntityResourceTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Drupal\Tests\next_jsonapi\Kernel\Controller;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\user\Entity\User;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @coversDefaultClass \Drupal\next_jsonapi\Controller\EntityResource
+ *
+ * @group next
+ */
+class EntityResourceTest extends KernelTestBase {
+
+  use NodeCreationTrait, UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'filter',
+    'next',
+    'node',
+    'field',
+    'system',
+    'user',
+    'jsonapi',
+    'path',
+    'serialization',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installConfig(['filter', 'next']);
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('node', ['node_access']);
+
+    $type = NodeType::create([
+      'type' => 'article',
+    ]);
+    $type->save();
+
+    foreach (range(1, 100) as $number) {
+      $article = $this->createNode([
+        'title' => "Article $number",
+        'type' => 'article',
+      ]);
+      $article->save();
+    }
+
+    $this->setCurrentUser(User::load(1));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+    $container->setParameter('next_jsonapi.size_max', 60);
+    if ($container->hasDefinition('jsonapi.entity_resource')) {
+      $definition = $container->getDefinition('jsonapi.entity_resource');
+      $definition->setClass('Drupal\next_jsonapi\Controller\EntityResource')
+        ->addArgument('%next_jsonapi.size_max%');
+    }
+  }
+
+  /**
+   * Tests the page limit.
+   *
+   * @covers ::getJsonApiParams()
+   */
+  public function testPageLimit() {
+    /** @var \Drupal\next_jsonapi\Controller\EntityResource $entity_resource */
+    $entity_resource = $this->container->get('jsonapi.entity_resource');
+    /** @var \Drupal\jsonapi\ResourceType\ResourceTypeRepositoryInterface $entity_type_repository */
+    $entity_type_repository = $this->container->get('jsonapi.resource_type.repository');
+    $resource_type = $entity_type_repository->get('node', 'article');
+
+    // Default using \Drupal\jsonapi\Query\OffsetPage::SIZE_MAX.
+    $request = Request::create('/jsonapi/node/article');
+    $request->query = new ParameterBag();
+    $response = $entity_resource->getCollection($resource_type, $request);
+    $data = $response->getResponseData()->getData();
+    $this->assertSame(50, $data->count());
+
+    // With page limit.
+    $request = Request::create('/jsonapi/node/article');
+    $request->query = new ParameterBag([
+      'page' => [
+        'limit' => 10,
+      ],
+    ]);
+    $response = $entity_resource->getCollection($resource_type, $request);
+    $data = $response->getResponseData()->getData();
+    $this->assertSame(10, $data->count());
+
+    // With page limit and offset.
+    $request = Request::create('/jsonapi/node/article');
+    $request->query = new ParameterBag([
+      'page' => [
+        'offset' => 2,
+        'limit' => 5,
+      ],
+    ]);
+    $response = $entity_resource->getCollection($resource_type, $request);
+    $data = $response->getResponseData()->getData();
+    $this->assertSame(5, $data->count());
+
+    // With fields as sparse fieldset.
+    $request = Request::create('/jsonapi/node/article');
+    $request->query = new ParameterBag([
+      'fields' => [
+        'node--article' => 'title',
+      ],
+    ]);
+    $response = $entity_resource->getCollection($resource_type, $request);
+    $data = $response->getResponseData()->getData();
+    $this->assertSame(50, $data->count());
+
+    // Using sparse fieldset path override.
+    $request = Request::create('/jsonapi/node/article');
+    $request->query = new ParameterBag([
+      'fields' => [
+        'node--article' => 'path,title',
+      ],
+    ]);
+    $response = $entity_resource->getCollection($resource_type, $request);
+    $data = $response->getResponseData()->getData();
+    $this->assertSame(60, $data->count());
+
+    // Using sparse fieldset path override and limit.
+    $request = Request::create('/jsonapi/node/article');
+    $request->query = new ParameterBag([
+      'fields' => [
+        'node--article' => 'path,title',
+      ],
+      'page' => [
+        'limit' => 5,
+      ],
+    ]);
+    $response = $entity_resource->getCollection($resource_type, $request);
+    $data = $response->getResponseData()->getData();
+    $this->assertSame(5, $data->count());
+
+    // Using sparse fieldset path override and limit.
+    $request = Request::create('/jsonapi/node/article');
+    $request->query = new ParameterBag([
+      'fields' => [
+        'node--article' => 'path,title',
+      ],
+      'page' => [
+        'limit' => 80,
+      ],
+    ]);
+    $response = $entity_resource->getCollection($resource_type, $request);
+    $data = $response->getResponseData()->getData();
+    $this->assertSame(80, $data->count());
+  }
+
+}

--- a/modules/next/modules/next_jsonapi/tests/src/Kernel/Controller/EntityResourceTest.php
+++ b/modules/next/modules/next_jsonapi/tests/src/Kernel/Controller/EntityResourceTest.php
@@ -79,7 +79,7 @@ class EntityResourceTest extends KernelTestBase {
   /**
    * Tests the page limit.
    *
-   * @covers ::getJsonApiParams()
+   * @covers ::getJsonApiParams
    */
   public function testPageLimit() {
     /** @var \Drupal\next_jsonapi\Controller\EntityResource $entity_resource */


### PR DESCRIPTION
Allows the max size to be set via `page[limit]` even when using `path` in sparse fieldset.