### PR TITLE
fix(next): size_max should be a hard limit

### DIFF
--- a/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
+++ b/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
@@ -94,7 +94,7 @@ class EntityResource extends JsonApiEntityResource {
     $max = $this->maxSize;
 
     // Fallback to page[limit] if set.
-    if (($page = $request->query->get('page')) && isset($page['limit'])) {
+    if (($page = $request->query->get('page')) && isset($page['limit']) && $page['limit'] < $max) {
       $max = $page['limit'];
     }
 

--- a/modules/next/modules/next_jsonapi/tests/src/Kernel/Controller/EntityResourceTest.php
+++ b/modules/next/modules/next_jsonapi/tests/src/Kernel/Controller/EntityResourceTest.php
@@ -106,6 +106,17 @@ class EntityResourceTest extends KernelTestBase {
     $data = $response->getResponseData()->getData();
     $this->assertSame(10, $data->count());
 
+    // With page limit over size max.
+    $request = Request::create('/jsonapi/node/article');
+    $request->query = new ParameterBag([
+      'page' => [
+        'limit' => 100,
+      ],
+    ]);
+    $response = $entity_resource->getCollection($resource_type, $request);
+    $data = $response->getResponseData()->getData();
+    $this->assertSame(50, $data->count());
+
     // With page limit and offset.
     $request = Request::create('/jsonapi/node/article');
     $request->query = new ParameterBag([
@@ -166,7 +177,7 @@ class EntityResourceTest extends KernelTestBase {
     ]);
     $response = $entity_resource->getCollection($resource_type, $request);
     $data = $response->getResponseData()->getData();
-    $this->assertSame(80, $data->count());
+    $this->assertSame(60, $data->count());
   }
 
 }


### PR DESCRIPTION
Follow up from #333 we should treat `next_jsonapi.size_max` as a hard limit.