### PR TITLE
ci: switch to pull_request_target

### DIFF
--- a/.github/workflows/next-drupal.yml
+++ b/.github/workflows/next-drupal.yml
@@ -1,8 +1,9 @@
 name: next-drupal
 on:
   push:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, edited]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
This PR switches the `next-drupal` workflow to using `pull_request_target`. 

For added security we now require all PRs from outside collaborators to be approved.