### PR TITLE
fix(next): switch from InputBag::get to InputBag::all

### DIFF
--- a/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
+++ b/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
@@ -78,7 +78,7 @@ class EntityResource extends JsonApiEntityResource {
     // SPEC: https://jsonapi.org/format/#fetching-sparse-fieldsets
     $sparse_fieldset = array_map(function ($item) {
       return explode(',', $item);
-    }, $request->query->get('fields'));
+    }, $request->query->all('fields'));
 
     if (!isset($sparse_fieldset[$resource_type->getTypeName()])) {
       return $params;
@@ -94,7 +94,7 @@ class EntityResource extends JsonApiEntityResource {
     $max = $this->maxSize;
 
     // Fallback to page[limit] if set.
-    if (($page = $request->query->get('page')) && isset($page['limit']) && $page['limit'] < $max) {
+    if (($page = $request->query->all('page')) && isset($page['limit']) && $page['limit'] < $max) {
       $max = $page['limit'];
     }
 

--- a/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
+++ b/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
@@ -72,13 +72,16 @@ class EntityResource extends JsonApiEntityResource {
       return $params;
     }
 
+    $query = $request->query->all();
+
     // Increase the max size if path is requested as the first field.
     // We do this to overcome the max size limit when building paths for
     // getStaticPaths.
     // SPEC: https://jsonapi.org/format/#fetching-sparse-fieldsets
     $sparse_fieldset = array_map(function ($item) {
       return explode(',', $item);
-    }, $request->query->all('fields'));
+    }, $query['fields']);
+
 
     if (!isset($sparse_fieldset[$resource_type->getTypeName()])) {
       return $params;
@@ -94,7 +97,7 @@ class EntityResource extends JsonApiEntityResource {
     $max = $this->maxSize;
 
     // Fallback to page[limit] if set.
-    if (($page = $request->query->all('page')) && isset($page['limit']) && $page['limit'] < $max) {
+    if (isset($query['page']) && ($page = $query['page']) && isset($page['limit']) && $page['limit'] < $max) {
       $max = $page['limit'];
     }
 

--- a/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
+++ b/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
@@ -82,7 +82,6 @@ class EntityResource extends JsonApiEntityResource {
       return explode(',', $item);
     }, $query['fields']);
 
-
     if (!isset($sparse_fieldset[$resource_type->getTypeName()])) {
       return $params;
     }


### PR DESCRIPTION
From https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/HttpFoundation/CHANGELOG.md#60

> Retrieving non-scalar values using InputBag::get() will throw BadRequestException (use InputBad::all() instead to retrieve an array)

Fixes #403 