### PR TITLE
Fix exception when no sites are configured on entity

### DIFF
--- a/modules/next/src/Render/MainContent/HtmlRenderer.php
+++ b/modules/next/src/Render/MainContent/HtmlRenderer.php
@@ -114,7 +114,7 @@ class HtmlRenderer extends CoreHtmlRenderer {
 
     $sites = $next_entity_type_config->getSiteResolver()->getSitesForEntity($entity);
     if (!count($sites)) {
-      throw new \Exception('Next.js sites for the entity could not be resolved.');
+      return $build;
     }
 
     $config = $this->configFactory->get('next.settings');


### PR DESCRIPTION
When using the entity reference plugin for the preview, an exception is thrown when viewing the node view (in Drupal) if no sites are enabled on the node. It should fallback on default behaviour like it does when no "Next.js entity type" is configured.