### PR TITLE
Add cacheability metadata from the entity url

### DIFF
--- a/modules/next/src/Event/EntityActionEvent.php
+++ b/modules/next/src/Event/EntityActionEvent.php
@@ -75,7 +75,7 @@ class EntityActionEvent extends Event implements EntityActionEventInterface {
     $next_entity_type_manager = \Drupal::service('next.entity_type.manager');
 
     $sites = $next_entity_type_manager->getSitesForEntity($entity);
-    $url = $entity->hasLinkTemplate('canonical') ? $entity->toUrl()->toString() : NULL;
+    $url = $entity->hasLinkTemplate('canonical') ? $entity->toUrl()->toString(TRUE)->getGeneratedUrl() : NULL;
 
     return new static($entity, $action, $sites, $url);
   }


### PR DESCRIPTION
I was facing the same issue as described in: https://github.com/chapter-three/next-drupal/issues/421
After some debugging I figured out that the `$entity->toUrl()->toString()` in `modules/next/src/Event/EntityActionEvent.php::createFromEntity` was causing the early rendering when trying to authorize with Authorization Code grant type.
For more info see: https://www.lullabot.com/articles/early-rendering-a-lesson-in-debugging-drupal-8