### PR TITLE
fix: fix typo on page-limit docs

### DIFF
--- a/www/content/guides/page-limit.mdx
+++ b/www/content/guides/page-limit.mdx
@@ -17,7 +17,7 @@ Tip: If you have a site with a large number of pages, consider using on-demand g
 
 ## Configuration
 
-To override the page max size, set the following `parameter` in your Drupal `settings.yml` file and clear caches.
+To override the page max size, set the following `parameter` in your Drupal `services.yml` file and clear caches.
 
 ```yaml
 parameters:


### PR DESCRIPTION
Fixed a typo on page limit docs, we should add `next_jsonapi.size_max` to parameters in `sites/default/services.yml`.