### PR TITLE
Update types.ts: add default field 'promote' to DrupalNode

### DIFF
--- a/packages/next-drupal/src/types.ts
+++ b/packages/next-drupal/src/types.ts
@@ -429,6 +429,7 @@ export interface DrupalNode extends JsonApiResourceWithPath {
   title: string
   default_langcode: boolean
   sticky: boolean
+  promote: boolean
 }
 
 export interface DrupalParagraph extends JsonApiResource {


### PR DESCRIPTION
Added default field 'promote' to DrupalNode