### PR TITLE
Issue #500: Fix wrong iFrame preview URL on "Latest version" tab for translations

### DIFF
--- a/modules/next/src/NextEntityTypeManager.php
+++ b/modules/next/src/NextEntityTypeManager.php
@@ -74,7 +74,7 @@ class NextEntityTypeManager implements NextEntityTypeManagerInterface {
       }
 
       if ($route_match->getRouteName() === 'entity.node.latest_version') {
-        $node_revision = $route_match->getParameter('node')->getRevisionId();
+        return $route_match->getParameter('node');
       }
 
       return $this->entityTypeManager->getStorage('node')->loadRevision($node_revision);


### PR DESCRIPTION
The previous method `EntityStorage::loadRevision()` loses specific language information. Some `getTranslation($langcode)` should be added, but its not really needed as `$route_match->getParameter('node')` already contains the correct revision and langcode information.