### PR TITLE
Lint Drupal's PHP coding standards

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -68,15 +68,13 @@ jobs:
           cd ~/drupal
           COMPOSER_MEMORY_LIMIT=-1 composer require --dev phpspec/prophecy-phpunit:^2 -W
         if: ${{ startsWith(matrix.drupal, '9') }}
+      - name: Run phpcs
+        run: |
+          ~/drupal/vendor/bin/phpcs -p -s --colors --standard=modules/next/phpcs.xml modules/next
       - name: Copy module
         run: cp -R ../next-drupal/modules/next ~/drupal/web/modules/next
       - name: Run php built-in server
         run: php -S 127.0.0.1:8080 -t ~/drupal/web &
-      - name: Run phpcs
-        run: |
-          cd ~/drupal/web
-          cp modules/next/phpcs.xml.dist .
-          ../vendor/bin/phpcs -p -s --colors --standard=./phpcs.xml.dist modules/next
       - name: Run PHPUnit
         run: |
           cd ~/drupal/web

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           cd ~/drupal/web
           cp modules/next/phpcs.xml.dist .
-          ../vendor/bin/phpcs --standard=./phpcs.xml.dist modules/next -p -s -n --colors
+          ../vendor/bin/phpcs -p -s --colors --standard=./phpcs.xml.dist modules/next
       - name: Run PHPUnit
         run: |
           cd ~/drupal/web

--- a/modules/next/modules/next_extras/src/Plugin/Field/FieldType/ContentTranslationsFieldItemList.php
+++ b/modules/next/modules/next_extras/src/Plugin/Field/FieldType/ContentTranslationsFieldItemList.php
@@ -6,7 +6,7 @@ use Drupal\Core\Field\FieldItemList;
 use Drupal\Core\TypedData\ComputedItemListTrait;
 
 /**
- * Class ContentTranslationsFieldItemList.
+ * A list of field item objects with translations.
  */
 class ContentTranslationsFieldItemList extends FieldItemList {
 

--- a/modules/next/modules/next_jwt/src/EventSubscriber/JwtEventSubscriber.php
+++ b/modules/next/modules/next_jwt/src/EventSubscriber/JwtEventSubscriber.php
@@ -9,7 +9,7 @@ use Drupal\next\NextSettingsManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Class JwtEventSubscriber.
+ * Subscribes to JWT authentication events.
  */
 class JwtEventSubscriber implements EventSubscriberInterface {
 

--- a/modules/next/modules/next_jwt/src/Plugin/Next/PreviewUrlGenerator/Jwt.php
+++ b/modules/next/modules/next_jwt/src/Plugin/Next/PreviewUrlGenerator/Jwt.php
@@ -11,7 +11,6 @@ use Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\jwt\Authentication\Provider\JwtAuth;
-use Drupal\next\Annotation\PreviewUrlGenerator;
 use Drupal\next\Entity\NextSiteInterface;
 use Drupal\next\Exception\InvalidPreviewUrlRequest;
 use Drupal\next\Plugin\ConfigurablePreviewUrlGeneratorBase;
@@ -142,7 +141,8 @@ class Jwt extends ConfigurablePreviewUrlGeneratorBase {
     $query['timestamp'] = $timestamp = $this->time->getRequestTime();
     $query['secret'] = $secret = $this->previewSecretGenerator->generate($timestamp . $slug . $resource_version . $this->user->uuid());
 
-    // Generate a JWT and store it temporarily so that we can retrieve it on validate.
+    // Generate a JWT and store it temporarily so that we can retrieve it on
+    // validate.
     $jwt = $this->jwtAuth->generateToken();
     $this->keyValue->get('next_jwt')
       ->setWithExpire($secret, $jwt, $this->configuration['access_token_expiration']);

--- a/modules/next/phpcs.xml
+++ b/modules/next/phpcs.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="Drupal coding standards">
+<ruleset name="DrupalProjectNext">
+  <!-- Ignore files -->
   <exclude-pattern>*/config/*</exclude-pattern>
   <exclude-pattern>*/css/*</exclude-pattern>
   <exclude-pattern>*/js/*</exclude-pattern>
 
   <rule ref="Drupal"/>
+  <rule ref="DrupalPractice"/>
 </ruleset>

--- a/modules/next/phpcs.xml
+++ b/modules/next/phpcs.xml
@@ -1,12 +1,8 @@
-<?xml version="1.0"?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="Drupal coding standards">
-  <exclude-pattern>*/.git/*</exclude-pattern>
   <exclude-pattern>*/config/*</exclude-pattern>
   <exclude-pattern>*/css/*</exclude-pattern>
   <exclude-pattern>*/js/*</exclude-pattern>
-  <exclude-pattern>*/vendor/*</exclude-pattern>
-  <exclude-pattern>\.md</exclude-pattern>
 
   <rule ref="Drupal"/>
 </ruleset>

--- a/modules/next/src/Controller/NextSiteEntityController.php
+++ b/modules/next/src/Controller/NextSiteEntityController.php
@@ -107,7 +107,7 @@ class NextSiteEntityController extends ControllerBase {
         '#context' => [
           'name' => $name,
           'value' => $value,
-        ]
+        ],
       ];
     }
 

--- a/modules/next/src/Entity/NextEntityTypeConfig.php
+++ b/modules/next/src/Entity/NextEntityTypeConfig.php
@@ -3,7 +3,6 @@
 namespace Drupal\next\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityBase;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\next\Plugin\RevalidatorInterface;
 use Drupal\next\Plugin\SiteResolverInterface;
 use Drupal\next\RevalidatorPluginCollection;

--- a/modules/next/src/Entity/NextEntityTypeConfigInterface.php
+++ b/modules/next/src/Entity/NextEntityTypeConfigInterface.php
@@ -3,12 +3,9 @@
 namespace Drupal\next\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityWithPluginCollectionInterface;
 use Drupal\next\Plugin\RevalidatorInterface;
 use Drupal\next\Plugin\SiteResolverInterface;
-use Drupal\next\RevalidatorPluginCollection;
-use Drupal\next\SiteResolverPluginCollection;
 
 /**
  * Provides an interface for next_entity_type_config entity definitions.

--- a/modules/next/src/Entity/NextSite.php
+++ b/modules/next/src/Entity/NextSite.php
@@ -176,8 +176,8 @@ class NextSite extends ConfigEntityBase implements NextSiteInterface {
    * {@inheritdoc}
    */
   public function getPreviewUrlForEntity(EntityInterface $entity): Url {
-    // Anonymous users do not have access to the preview url.
-    // Same for authenticated users with no additional roles, since we assume no scope.
+    // Anonymous users do not have access to the preview url. Same for
+    // authenticated users with no additional roles, since we assume no scope.
     if (\Drupal::currentUser()->isAnonymous() || (!count(\Drupal::currentUser()->getRoles(TRUE)) && \Drupal::currentUser()->id() !== "1")) {
       return $this->getLiveUrlForEntity($entity);
     }
@@ -190,20 +190,21 @@ class NextSite extends ConfigEntityBase implements NextSiteInterface {
       /** @var \Drupal\Core\Entity\RevisionableInterface $entity */
       $rel = NULL;
 
-      // In Drupal terms, a "working copy" is the latest revision. It may or may not
-      // be a "default" revision. This revision is the working copy because it is
-      // the revision to which new work will be applied. In other words, it denotes
-      // the most recent revision which might be considered a work-in-progress.
+      // In Drupal terms, a "working copy" is the latest revision. It may or may
+      // not be a "default" revision. This revision is the working copy because
+      // it is the revision to which new work will be applied. In other words,
+      // it denotes the most recent revision which might be considered a
+      // work-in-progress.
       // @see \Drupal\jsonapi\Revisions\VersionByRel
       if ($entity->isLatestRevision()) {
         $rel = 'working-copy';
       }
 
-      // In Drupal terms, the "latest version" is the latest "default" revision. It
-      // may or may not have later revisions after it, as long as none of them are
-      // "default" revisions. This revision is the latest version because it is the
-      // last revision where work was considered finished. Typically, this means
-      // that it is the most recent "published" revision.
+      // In Drupal terms, the "latest version" is the latest "default" revision.
+      // It may or may not have later revisions after it, as long as none of
+      // them are "default" revisions. This revision is the latest version
+      // because it is the last revision where work was considered finished.
+      // Typically, this means that it is the most recent "published" revision.
       // @see \Drupal\jsonapi\Revisions\VersionByRel
       if ($entity->isDefaultRevision()) {
         $rel = 'latest-version';
@@ -211,7 +212,7 @@ class NextSite extends ConfigEntityBase implements NextSiteInterface {
       $resource_version = $rel ? "rel:$rel" : "id:{$entity->getRevisionId()}";
     }
 
-    // TODO: Extract this to a service.
+    // @todo Extract this to a service.
     /** @var \Drupal\next\NextSettingsManagerInterface $next_settings */
     $next_settings = \Drupal::service('next.settings.manager');
     $preview_url_generator = $next_settings->getPreviewUrlGenerator();
@@ -228,8 +229,8 @@ class NextSite extends ConfigEntityBase implements NextSiteInterface {
 
     $query = $preview_url->getOption('query');
 
-    // Add the plugin to the query.
-    // This allows next.js app to determine the preview strategy based on the plugin.
+    // Add the plugin to the query. This allows next.js app to determine the
+    // preview strategy based on the plugin.
     $query['plugin'] = $preview_url_generator->getId();
 
     // Add the locale to the query.

--- a/modules/next/src/Event/EntityActionEventInterface.php
+++ b/modules/next/src/Event/EntityActionEventInterface.php
@@ -20,7 +20,9 @@ interface EntityActionEventInterface {
   public const UPDATE_ACTION = 'update';
 
   /**
-   * The entity delete action. We use predelete because we need access to the entity for revalidating.
+   * The entity delete action.
+   *
+   * We use predelete because we need access to the entity for revalidating.
    */
   public const DELETE_ACTION = 'delete';
 

--- a/modules/next/src/Event/EntityRevalidatedEvent.php
+++ b/modules/next/src/Event/EntityRevalidatedEvent.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\next\Event;
 
-use Drupal\Core\Entity\EntityInterface;
-
 /**
  * Defines an entity revalidated event.
  *

--- a/modules/next/src/Form/NextEntityTypeConfigDeleteForm.php
+++ b/modules/next/src/Form/NextEntityTypeConfigDeleteForm.php
@@ -6,7 +6,7 @@ use Drupal\Core\Entity\EntityDeleteForm;
 use Drupal\Core\Url;
 
 /**
- * Provides a deletion confirmation form for the next_entity_type_config deletion form.
+ * Provides a deletion confirmation form for next_entity_type_config.
  */
 class NextEntityTypeConfigDeleteForm extends EntityDeleteForm {
 

--- a/modules/next/src/Form/NextEntityTypeConfigForm.php
+++ b/modules/next/src/Form/NextEntityTypeConfigForm.php
@@ -62,8 +62,10 @@ class NextEntityTypeConfigForm extends EntityForm {
    */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, SiteResolverManagerInterface $site_resolver_manager, RevalidatorManagerInterface $revalidator_manager = NULL) {
     if (!$revalidator_manager) {
-      @trigger_error('Calling NextEntityTypeConfigForm::__construct() without the $revalidator_manager argument is deprecated in next:1.4.0. The $revalidator_manager argument will be required in next:2.0.0. See https://www.drupal.org/project/next/releases/1.4.0', E_USER_DEPRECATED);
+      @trigger_error('Calling NextEntityTypeConfigForm::__construct() without the $revalidator_manager argument is deprecated in next:1.4.0 and will be required in next:2.0.0. See https://www.drupal.org/node/3325622', E_USER_DEPRECATED);
+      // @codingStandardsIgnoreStart
       $revalidator_manager = \Drupal::service('plugin.manager.next.revalidator');
+      // @codingStandardsIgnoreEnd
     }
 
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/next/src/Form/NextSettingsForm.php
+++ b/modules/next/src/Form/NextSettingsForm.php
@@ -43,8 +43,10 @@ class NextSettingsForm extends ConfigFormBase {
    */
   public function __construct(ConfigFactoryInterface $config_factory, SitePreviewerManagerInterface $site_previewer_manager, PreviewUrlGeneratorManagerInterface $preview_url_generator_manager = NULL) {
     if (!$preview_url_generator_manager) {
-      @trigger_error('Calling NextSettingsForm::__construct() without the $preview_url_generator_manager argument is deprecated in next:1.3.0. The $preview_url_generator_manager argument will be required in next:2.0.0. See https://www.drupal.org/project/next/releases/1.3.0', E_USER_DEPRECATED);
+      @trigger_error('Calling NextSettingsForm::__construct() without the $preview_url_generator_manager argument is deprecated in next:1.3.0 and will be required in next:2.0.0. See https://www.drupal.org/node/3308330', E_USER_DEPRECATED);
+      // @codingStandardsIgnoreStart
       $preview_url_generator_manager = \Drupal::service('plugin.manager.next.preview_url_generator');
+      // @codingStandardsIgnoreEnd
     }
 
     parent::__construct($config_factory);

--- a/modules/next/src/NextEntityTypeManager.php
+++ b/modules/next/src/NextEntityTypeManager.php
@@ -65,7 +65,7 @@ class NextEntityTypeManager implements NextEntityTypeManagerInterface {
   public function getEntityFromRouteMatch(RouteMatchInterface $route_match): ?EntityInterface {
     $entity_types_ids = $this->getConfigEntityTypeIds();
 
-    // TODO: Handle all revisionable entity types.
+    // @todo Handle all revisionable entity types.
     $revision_routes = ['entity.node.revision', 'entity.node.latest_version'];
     if (in_array($route_match->getRouteName(), $revision_routes) && in_array('node', $entity_types_ids)) {
       $node_revision = $route_match->getParameter('node_revision');
@@ -93,9 +93,12 @@ class NextEntityTypeManager implements NextEntityTypeManagerInterface {
    * {@inheritdoc}
    */
   public function isEntityRevisionable(EntityInterface $entity): bool {
+    // @todo How do you do dependency injection on optional dependencies?
+    // @codingStandardsIgnoreStart
     if (\Drupal::hasService('jsonapi.resource_type.repository')) {
-      /* @var \Drupal\jsonapi\ResourceType\ResourceTypeRepositoryInterface $resource_type_repository */
+      /** @var \Drupal\jsonapi\ResourceType\ResourceTypeRepositoryInterface $resource_type_repository */
       $resource_type_repository = \Drupal::service('jsonapi.resource_type.repository');
+      // @codingStandardsIgnoreEnd
       $resource = $resource_type_repository->get($entity->getEntityTypeId(), $entity->bundle());
       return $resource->isVersionable() && $entity->getEntityType()->isRevisionable();
     }

--- a/modules/next/src/Plugin/Next/PreviewUrlGenerator/SimpleOauth.php
+++ b/modules/next/src/Plugin/Next/PreviewUrlGenerator/SimpleOauth.php
@@ -11,7 +11,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
-use Drupal\next\Annotation\PreviewUrlGenerator;
 use Drupal\next\Entity\NextSiteInterface;
 use Drupal\next\Exception\InvalidPreviewUrlRequest;
 use Drupal\next\Plugin\ConfigurablePreviewUrlGeneratorBase;

--- a/modules/next/src/Plugin/Next/Revalidator/Path.php
+++ b/modules/next/src/Plugin/Next/Revalidator/Path.php
@@ -3,7 +3,6 @@
 namespace Drupal\next\Plugin\Next\Revalidator;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\next\Annotation\Revalidator;
 use Drupal\next\Event\EntityActionEvent;
 use Drupal\next\Plugin\ConfigurableRevalidatorBase;
 use Drupal\next\Plugin\RevalidatorInterface;

--- a/modules/next/src/Plugin/Next/SitePreviewer/Iframe.php
+++ b/modules/next/src/Plugin/Next/SitePreviewer/Iframe.php
@@ -10,7 +10,6 @@ use Drupal\Core\Entity\RevisionableInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Url;
 use Drupal\next\Form\IframeSitePreviewerSwitcherForm;
 use Drupal\next\Plugin\ConfigurableSitePreviewerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -191,7 +190,7 @@ class Iframe extends ConfigurableSitePreviewerBase implements ContainerFactoryPl
           'class' => [
             $entity->isPublished() ? 'published' : '',
           ],
-        ]
+        ],
       ];
     }
 
@@ -243,8 +242,8 @@ class Iframe extends ConfigurableSitePreviewerBase implements ContainerFactoryPl
             'iframe_preview' => [
               'sync_route' => $this->configuration['sync_route'],
               'skip_routes' => array_map('trim', explode("\n", mb_strtolower($this->configuration['sync_route_skip_routes']))),
-            ]
-          ]
+            ],
+          ],
         ],
         'library' => [
           'next/site_preview.iframe',

--- a/modules/next/src/Plugin/Next/SiteResolver/EntityReferenceField.php
+++ b/modules/next/src/Plugin/Next/SiteResolver/EntityReferenceField.php
@@ -19,7 +19,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @SiteResolver(
  *  id = "entity_reference_field",
  *  label = "Entity reference field",
- *  description = "This plugin allows you to select an entity reference field from which to resolve the Next.js site."
+ *  description = "This plugin allows you to select an entity reference field
+ *    from which to resolve the Next.js site."
  * )
  */
 class EntityReferenceField extends ConfigurableSiteResolverBase implements ContainerFactoryPluginInterface {

--- a/modules/next/src/Plugin/Next/SiteResolver/SiteSelector.php
+++ b/modules/next/src/Plugin/Next/SiteResolver/SiteSelector.php
@@ -16,7 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @SiteResolver(
  *  id = "site_selector",
  *  label = "Site selector",
- *  description = "The site selector plugin allows you to manually select the Next.js sites for the entity type."
+ *  description = "The site selector plugin allows you to manually select the
+ *    Next.js sites for the entity type."
  * )
  */
 class SiteSelector extends ConfigurableSiteResolverBase implements ContainerFactoryPluginInterface {

--- a/modules/next/src/Plugin/RevalidatorBase.php
+++ b/modules/next/src/Plugin/RevalidatorBase.php
@@ -6,7 +6,6 @@ use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\next\NextSettingsManagerInterface;
-use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/modules/next/src/Plugin/RevalidatorInterface.php
+++ b/modules/next/src/Plugin/RevalidatorInterface.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\next\Plugin;
 
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\next\Event\EntityActionEvent;
 
 /**

--- a/modules/next/src/Plugin/SitePreviewerManager.php
+++ b/modules/next/src/Plugin/SitePreviewerManager.php
@@ -6,7 +6,6 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\next\Annotation\SitePreviewer;
-use Drupal\next\Annotation\SiteResolver;
 
 /**
  * Plugin manager for site previewers.

--- a/modules/next/src/Render/MainContent/HtmlRenderer.php
+++ b/modules/next/src/Render/MainContent/HtmlRenderer.php
@@ -95,11 +95,11 @@ class HtmlRenderer extends CoreHtmlRenderer {
       return $build;
     }
 
-    // TODO: Make this configurable?
+    // @todo Make this configurable?
     $entity_type_id = $entity->getEntityTypeId();
     $revision_routes = $entity->getEntityType()->isRevisionable() ? [
       "entity.$entity_type_id.revision",
-      "entity.$entity_type_id.latest_version"
+      "entity.$entity_type_id.latest_version",
     ] : [];
     $routes = array_merge(["entity.$entity_type_id.canonical"], $revision_routes);
 

--- a/modules/next/tests/src/Kernel/Controller/NextPreviewUrlControllerTest.php
+++ b/modules/next/tests/src/Kernel/Controller/NextPreviewUrlControllerTest.php
@@ -50,7 +50,7 @@ class NextPreviewUrlControllerTest extends KernelTestBase {
       'id' => 'blog',
       'base_url' => 'https://blog.com',
       'preview_url' => 'https://blog.com/api/preview',
-      'preview_secret' => 'one'
+      'preview_secret' => 'one',
     ]);
     $this->nextSite->save();
 

--- a/modules/next/tests/src/Kernel/Controller/NextSiteEntityControllerTest.php
+++ b/modules/next/tests/src/Kernel/Controller/NextSiteEntityControllerTest.php
@@ -63,7 +63,7 @@ class NextSiteEntityControllerTest extends KernelTestBase {
    */
   public function testOverriddenEnvironmentVariables() {
     $GLOBALS['config']['next.next_site.' . $this->nextSite->id()] = [
-      'preview_secret' => 'overridden'
+      'preview_secret' => 'overridden',
     ];
     $overridden_entity = NextSite::load($this->nextSite->id());
     $controller = NextSiteEntityController::create($this->container);

--- a/modules/next/tests/src/Kernel/Entity/NextEntityTypeConfigTest.php
+++ b/modules/next/tests/src/Kernel/Entity/NextEntityTypeConfigTest.php
@@ -52,7 +52,7 @@ class NextEntityTypeConfigTest extends KernelTestBase {
    */
   public function testSiteResolver() {
     $blog_site = NextSite::create([
-      'id' => 'blog'
+      'id' => 'blog',
     ]);
     $blog_site->save();
 
@@ -116,7 +116,7 @@ class NextEntityTypeConfigTest extends KernelTestBase {
    */
   public function testRevalidator() {
     $blog_site = NextSite::create([
-      'id' => 'blog'
+      'id' => 'blog',
     ]);
     $blog_site->save();
 

--- a/modules/next/tests/src/Kernel/Entity/NextSiteTest.php
+++ b/modules/next/tests/src/Kernel/Entity/NextSiteTest.php
@@ -48,7 +48,7 @@ class NextSiteTest extends KernelTestBase {
       'id' => 'blog',
       'base_url' => 'https://blog.com',
       'preview_url' => 'https://blog.com/api/preview',
-      'preview_secret' => 'one'
+      'preview_secret' => 'one',
     ]);
     $this->nextSite->save();
 

--- a/modules/next/tests/src/Kernel/Event/EntityRevalidatedEventTest.php
+++ b/modules/next/tests/src/Kernel/Event/EntityRevalidatedEventTest.php
@@ -6,7 +6,6 @@ use Drupal\Core\Database\Database;
 use Drupal\dblog\Controller\DbLogController;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\next\Entity\NextEntityTypeConfig;
-use Drupal\node\Entity\NodeType;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**

--- a/modules/next/tests/src/Kernel/NextEntityTypeManagerTest.php
+++ b/modules/next/tests/src/Kernel/NextEntityTypeManagerTest.php
@@ -5,8 +5,6 @@ namespace Drupal\Tests\next\Kernel\Plugin;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\next\Entity\NextEntityTypeConfig;
 use Drupal\next\Entity\NextSite;
-use Drupal\next\Plugin\Next\PreviewUrlGenerator\SimpleOauth;
-use Drupal\next\Plugin\Next\SitePreviewer\Iframe;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**
@@ -48,7 +46,7 @@ class NextEntityTypeManagerTest extends KernelTestBase {
     $this->assertEmpty($next_entity_type_manager->getSitesForEntity($page));
 
     $blog_site = NextSite::create([
-      'id' => 'blog'
+      'id' => 'blog',
     ]);
     $blog_site->save();
     $this->assertEmpty($next_entity_type_manager->getSitesForEntity($page));
@@ -93,7 +91,7 @@ class NextEntityTypeManagerTest extends KernelTestBase {
     $this->assertEmpty($next_entity_type_manager->getSiteResolver($page));
 
     $blog_site = NextSite::create([
-      'id' => 'blog'
+      'id' => 'blog',
     ]);
     $blog_site->save();
     $this->assertEmpty($next_entity_type_manager->getSiteResolver($page));

--- a/modules/next/tests/src/Kernel/Plugin/PathRevalidatorTest.php
+++ b/modules/next/tests/src/Kernel/Plugin/PathRevalidatorTest.php
@@ -57,7 +57,7 @@ class PathRevalidatorTest extends KernelTestBase {
     $this->container->set('http_client', $client->reveal());
 
     $blog_site = NextSite::create([
-      'id' => 'blog'
+      'id' => 'blog',
     ]);
     $blog_site->save();
 
@@ -108,7 +108,7 @@ class PathRevalidatorTest extends KernelTestBase {
     _drupal_shutdown_function();
 
     $entity_type_config->setRevalidatorConfiguration('path', [
-      'additional_paths' => "/\n/blog"
+      'additional_paths' => "/\n/blog",
     ])->save();
 
     $client->request('GET', 'http://marketing.com/api/revalidate?slug=/node/3&secret=12345')->shouldBeCalled();

--- a/modules/next/tests/src/Kernel/Plugin/SiteResolverTest.php
+++ b/modules/next/tests/src/Kernel/Plugin/SiteResolverTest.php
@@ -55,7 +55,7 @@ class SiteResolverTest extends KernelTestBase {
       'id' => 'blog',
       'base_url' => 'https://blog.com',
       'preview_url' => 'https://blog.com/api/preview',
-      'preview_secret' => 'one'
+      'preview_secret' => 'one',
     ]);
     $blog->save();
 
@@ -64,7 +64,7 @@ class SiteResolverTest extends KernelTestBase {
       'id' => 'marketing',
       'base_url' => 'https://marketing.com',
       'preview_url' => 'https://marketing.com/api/preview',
-      'preview_secret' => 'two'
+      'preview_secret' => 'two',
     ]);
     $marketing->save();
 

--- a/modules/next/tests/src/Kernel/Renderer/MainContent/HtmlRendererTest.php
+++ b/modules/next/tests/src/Kernel/Renderer/MainContent/HtmlRendererTest.php
@@ -58,7 +58,7 @@ class HtmlRendererTest extends KernelTestBase {
       'id' => 'blog',
       'base_url' => 'https://blog.com',
       'preview_url' => 'https://blog.com/api/preview',
-      'preview_secret' => 'one'
+      'preview_secret' => 'one',
     ]);
     $blog->save();
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "lerna run prepare && husky install",
     "watch": "lerna run watch",
     "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
-    "phpcs": "./drupal/vendor/bin/phpcs -s -n --colors --standard=modules/next/phpcs.xml.dist modules/next",
+    "phpcs": "./drupal/vendor/bin/phpcs -p -s --colors --standard=modules/next/phpcs.xml.dist modules/next",
     "test:next": "./drupal/vendor/bin/phpunit -c ./drupal/web modules/next",
     "sync:modules": "./scripts/sync-modules.sh \"modules/*\"",
     "sync:examples": "./scripts/sync-examples.sh \"examples/example-*\"",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "lerna run prepare && husky install",
     "watch": "lerna run watch",
     "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
-    "phpcs": "./drupal/vendor/bin/phpcs -p -s --colors --standard=modules/next/phpcs.xml.dist modules/next",
+    "phpcs": "./drupal/vendor/bin/phpcs -p -s --colors --standard=modules/next/phpcs.xml modules/next",
     "test:next": "./drupal/vendor/bin/phpunit -c ./drupal/web modules/next",
     "sync:modules": "./scripts/sync-modules.sh \"modules/*\"",
     "sync:examples": "./scripts/sync-examples.sh \"examples/example-*\"",


### PR DESCRIPTION
This pull request is for:
- [x] `modules/next`

GitHub Issue: #551

## Describe your changes

Instead of only linting some of code sniffs, lint all of Drupal's PHP coding standards.
