### PR TITLE
chore: update GitHub issue templates' package chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,6 +13,7 @@ body:
       label: Package containing the bug
       description: What package in this monorepo has the bug?
       options:
+        - Not package-specific
         - I’m not sure
         - next (Drupal module)
         - next-drupal (NPM package)
@@ -31,7 +32,7 @@ body:
         - example-search-api
         - example-umami
         - example-webform
-      default: 0
+      default: 1
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,7 @@ body:
       label: Package
       description: The feature request is for what package in this monorepo?
       options:
+        - Not package-specific
         - I’m not sure
         - next (Drupal module)
         - next-drupal (NPM package)
@@ -26,7 +27,7 @@ body:
         - example-search-api
         - example-umami
         - example-webform
-      default: 0
+      default: 1
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -8,7 +8,7 @@ body:
       label: Package
       description: The question is for what package in this monorepo?
       options:
-        - Not applicable
+        - Not package-specific
         - I’m not sure
         - next (Drupal module)
         - next-drupal (NPM package)


### PR DESCRIPTION
This pull request is for: (mark with an "x")
- [x] Other

## Describe your changes

Update the GitHub issue templates to add a "not package-specific" option to the dropdown. This is helpful for issues related to CI or repo-wide tasks.
