### PR TITLE
build: remove unnecessary files from NPM package

### DIFF
--- a/packages/next-drupal-query/.npmignore
+++ b/packages/next-drupal-query/.npmignore
@@ -1,4 +1,3 @@
 /coverage
 /CHANGELOG.md
 /tests
-/tsconfig.json


### PR DESCRIPTION
This pull request is for: (mark with an "x")
- [ ] `examples/*`
- [ ] `modules/next`
- [x] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: #556

## Describe your changes

The NPM package has the src/ and tests/ files included and they are just bloat when downloading the package from npmjs.org.

Fixes #556
