### PR TITLE
fix(/starters/graphql-starter): add custom headers to support 4.6.0 r…

### DIFF
--- a/starters/graphql-starter/lib/drupal.ts
+++ b/starters/graphql-starter/lib/drupal.ts
@@ -30,6 +30,10 @@ export async function query<DataType>(payload: QueryPayload) {
     method: "POST",
     body: JSON.stringify(payload),
     withAuth: true, // Make authenticated requests using OAuth.
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
   })
 
   if (!response?.ok) {


### PR DESCRIPTION
…elease of the graphql moculde

This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [x ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: https://github.com/chapter-three/next-drupal/issues/588

- [x] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

The 4.6.0 release of the GraphQL module for Drupal added checks for the headers' "Content-Type" value in requests.  The existing `application/vnd.api+json` value from next-drupal's `client.ts` fails those tests so they must be changed to `application/json`.
