### PR TITLE
fix(next): next_entity_type_config dependencies

### DIFF
--- a/modules/next/src/Entity/NextEntityTypeConfig.php
+++ b/modules/next/src/Entity/NextEntityTypeConfig.php
@@ -241,6 +241,20 @@ class NextEntityTypeConfig extends ConfigEntityBase implements NextEntityTypeCon
   }
 
   /**
+   * {@inheritdoc}
+   *
+   * @todo add sites with onDependencyRemoval support.
+   */
+  public function calculateDependencies() {
+    parent::calculateDependencies();
+    [$entity_type_id, $bundle] = explode('.', $this->id());
+    $target_entity_type = $this->entityTypeManager()->getDefinition($entity_type_id);
+    $bundle_config_dependency = $target_entity_type->getBundleConfigDependency($bundle);
+    $this->addDependency($bundle_config_dependency['type'], $bundle_config_dependency['name']);
+    return $this;
+  }
+
+  /**
    * Wraps the site_resolver plugin manager.
    *
    * @return \Drupal\next\Plugin\SiteResolverManagerInterface

--- a/modules/next/tests/src/Kernel/Entity/NextEntityTypeConfigTest.php
+++ b/modules/next/tests/src/Kernel/Entity/NextEntityTypeConfigTest.php
@@ -140,4 +140,27 @@ class NextEntityTypeConfigTest extends KernelTestBase {
     $this->assertSame('path', $revalidator->getId());
   }
 
+  /**
+   * Tests config dependency calculation.
+   */
+  public function testConfigDependencies(): void {
+    $blog_site = NextSite::create([
+      'id' => 'blog',
+    ]);
+    $blog_site->save();
+
+    // Create entity type config.
+    /** @var \Drupal\next\Entity\NextEntityTypeConfigInterface $entity_type_config */
+    $entity_type_config = NextEntityTypeConfig::create([
+      'id' => 'node.page',
+      'site_resolver' => 'site_selector',
+      'configuration' => [
+        'sites' => [
+          'blog' => 'blog',
+        ],
+      ],
+    ]);
+    self::assertEquals([], $entity_type_config->getDependencies());
+  }
+
 }


### PR DESCRIPTION
Fixes #599,  dependencies in next_entity_type_config for the entity type and bundle being targeted.

This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: #599
_Please add a link to the GitHub issue
where this problem is discussed._

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

A clear and concise description of what the request is.

If applicable, add screenshots to help explain your issue.
