### PR TITLE
chore: fix test:next

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "phpcs": "./drupal/vendor/bin/phpcs -p -s --colors --standard=modules/next/phpcs.xml modules/next",
-    "test:next": "./drupal/vendor/bin/phpunit -c ./drupal/web modules/next",
+    "test:next": "SIMPLETEST_DB=sqlite://localhost/:memory: ./drupal/vendor/bin/phpunit -c ./drupal/web/core modules/next",
     "sync:modules": "./scripts/sync-modules.sh \"modules/*\"",
     "sync:examples": "./scripts/sync-examples.sh \"examples/example-*\"",
     "sync:starters": "./scripts/sync-starters.sh \"starters/*\"",


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [x] Other

## Describe your changes

The `test:next` script failed due to incorrect configuration path, and missing SIMPLETEST_DB environment variable. This runs the Drupal PHPUnit tests in memory with SQLite.

This fixes that path and sets the environment variable.
