### PR TITLE
fix(next): url form element for Next.js site form

### DIFF
--- a/modules/next/src/Form/NextSiteForm.php
+++ b/modules/next/src/Form/NextSiteForm.php
@@ -38,7 +38,7 @@ class NextSiteForm extends EntityForm {
     ];
 
     $form['base_url'] = [
-      '#type' => 'textfield',
+      '#type' => 'url',
       '#title' => $this->t('Base URL'),
       '#description' => $this->t('Enter the base URL for the Next.js site. Example: <em>https://example.com</em>.'),
       '#default_value' => $entity->getBaseUrl(),
@@ -60,7 +60,7 @@ class NextSiteForm extends EntityForm {
     ];
 
     $form['preview']['preview_url'] = [
-      '#type' => 'textfield',
+      '#type' => 'url',
       '#title' => $this->t('Preview URL'),
       '#description' => $this->t('Enter the preview URL. Example: <em>https://example.com/api/preview</em>.'),
       '#default_value' => $entity->getPreviewUrl(),
@@ -83,7 +83,7 @@ class NextSiteForm extends EntityForm {
     ];
 
     $form['revalidation']['revalidate_url'] = [
-      '#type' => 'textfield',
+      '#type' => 'url',
       '#title' => $this->t('Revalidate URL'),
       '#description' => $this->t('Enter the revalidate URL. Example: <em>https://example.com/api/revalidate</em>.'),
       '#default_value' => $entity->getRevalidateUrl(),


### PR DESCRIPTION
fixes #614

This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: #614

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

Uses the `url` form element for URL validation when creating or editing Next.js sites.