### PR TITLE
feat(next): dynamic consumer paths

### DIFF
--- a/modules/next/src/Controller/NextSiteEntityController.php
+++ b/modules/next/src/Controller/NextSiteEntityController.php
@@ -3,6 +3,7 @@
 namespace Drupal\next\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
 use Drupal\next\Entity\NextSiteInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -56,10 +57,11 @@ class NextSiteEntityController extends ControllerBase {
       'NEXT_IMAGE_DOMAIN' => $this->request->getHost(),
     ];
 
+    $path = Url::fromRoute('entity.consumer.collection')->toString();
     $variables += [
       'authentication_bearer' => '# Authentication',
-      'DRUPAL_CLIENT_ID' => 'Retrieve this from /admin/config/services/consumer',
-      'DRUPAL_CLIENT_SECRET' => 'Retrieve this from /admin/config/services/consumer',
+      'DRUPAL_CLIENT_ID' => 'Retrieve this from ' . $path,
+      'DRUPAL_CLIENT_SECRET' => 'Retrieve this from ' . $path,
     ];
 
     if ($secret = $next_site->getPreviewSecret()) {


### PR DESCRIPTION
Provides dynamic consumer paths from generated URL using Consumer
collection route.

fixes #615

This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: #
_Please add a link to the GitHub issue
where this problem is discussed._

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

A clear and concise description of what the request is.

If applicable, add screenshots to help explain your issue.
