### PR TITLE
ci(next): add Drupal 10.1 to CI test matrix

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -13,14 +13,9 @@ jobs:
     strategy:
       matrix:
         # Supported PHP versions: https://www.drupal.org/docs/getting-started/system-requirements/php-requirements
-        php: ["8.0", "8.1", "8.2"]
+        php: ["8.1", "8.2"]
         # Supported Drupal versions: https://www.drupal.org/project/drupal
-        drupal: ["9.5", "10.0"]
-        exclude:
-          - drupal: "9.5"
-            php: "8.2"
-          - drupal: "10.0"
-            php: "8.0"
+        drupal: ["10.0", "10.1"]
     name: Drupal ${{ matrix.drupal }} - PHP ${{ matrix.php }}
     services:
       mysql:


### PR DESCRIPTION
This pull request is for:

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: #543

## Describe your changes

Adds Drupal 10.1 to the GitHub test suite. I've also removed Drupal 9.5 since it is EOL. https://www.drupal.org/about/announcements/blog/drupal-9-is-end-of-life