### PR TITLE
ci(next): add Drupal 10.1 to CI test matrix

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       matrix:
         # Supported PHP versions: https://www.drupal.org/docs/getting-started/system-requirements/php-requirements
-        php: ["8.0", "8.1", "8.2"]
+        php: ["8.1", "8.2", "8.3"]
         # Supported Drupal versions: https://www.drupal.org/project/drupal
-        drupal: ["9.5", "10.0"]
+        drupal: ["10.0", "10.1"]
         exclude:
-          - drupal: "9.5"
-            php: "8.2"
           - drupal: "10.0"
-            php: "8.0"
+            php: "8.3"
+          - drupal: "10.1"
+            php: "8.3"
     name: Drupal ${{ matrix.drupal }} - PHP ${{ matrix.php }}
     services:
       mysql:
@@ -65,11 +65,6 @@ jobs:
           composer config allow-plugins true -n
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev --no-install
           composer install
-      - name: Add phpspec/prophecy-phpunit
-        run: |
-          cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require --dev phpspec/prophecy-phpunit:^2 -W
-        if: ${{ startsWith(matrix.drupal, '9') }}
       - name: Run phpcs
         run: |
           ~/drupal/vendor/bin/phpcs -p -s --colors --standard=modules/next/phpcs.xml modules/next

--- a/modules/next/tests/src/Kernel/Plugin/PathRevalidatorTest.php
+++ b/modules/next/tests/src/Kernel/Plugin/PathRevalidatorTest.php
@@ -7,6 +7,7 @@ use Drupal\next\Entity\NextEntityTypeConfig;
 use Drupal\next\Entity\NextSite;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -84,7 +85,7 @@ class PathRevalidatorTest extends KernelTestBase {
     $page->save();
     $this->container->get('kernel')->terminate(Request::create('/'), new Response());
 
-    $client->request('GET', 'http://blog.com/api/revalidate?slug=/node/2')->shouldBeCalled();
+    $client->request('GET', 'http://blog.com/api/revalidate?slug=/node/2')->shouldBeCalled()->willReturn(new GuzzleResponse());
     $blog_site->setRevalidateUrl('http://blog.com/api/revalidate')->save();
     $page = $this->createNode();
     $page->save();
@@ -103,8 +104,8 @@ class PathRevalidatorTest extends KernelTestBase {
       ],
     ])->save();
 
-    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/node/3&secret=12345')->shouldBeCalled();
-    $client->request('GET', 'http://blog.com/api/revalidate?slug=/node/3')->shouldBeCalled();
+    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/node/3&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://blog.com/api/revalidate?slug=/node/3')->shouldBeCalled()->willReturn(new GuzzleResponse());
     $page = $this->createNode();
     $page->save();
     $this->container->get('kernel')->terminate(Request::create('/'), new Response());
@@ -113,12 +114,12 @@ class PathRevalidatorTest extends KernelTestBase {
       'additional_paths' => "/\n/blog",
     ])->save();
 
-    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/node/3&secret=12345')->shouldBeCalled();
-    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/&secret=12345')->shouldBeCalled();
-    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/blog&secret=12345')->shouldBeCalled();
-    $client->request('GET', 'http://blog.com/api/revalidate?slug=/node/3')->shouldBeCalled();
-    $client->request('GET', 'http://blog.com/api/revalidate?slug=/')->shouldBeCalled();
-    $client->request('GET', 'http://blog.com/api/revalidate?slug=/blog')->shouldBeCalled();
+    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/node/3&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/blog&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://blog.com/api/revalidate?slug=/node/3')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://blog.com/api/revalidate?slug=/')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://blog.com/api/revalidate?slug=/blog')->shouldBeCalled()->willReturn(new GuzzleResponse());
     $page = $this->createNode();
     $page->save();
     $this->container->get('kernel')->terminate(Request::create('/'), new Response());


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: #547 

## Describe your changes

* Adds Drupal 10.1 to the GitHub test suite. 
* I've also removed Drupal 9.5 since it is EOL. https://www.drupal.org/about/announcements/blog/drupal-9-is-end-of-life
* PHP 8.0 is not supported by any version of Drupal 10, so it's been removed as well. https://www.drupal.org/docs/getting-started/system-requirements/php-requirements
* A comment in #547 [explains the GuzzleHttp Response additions that fixed a failing test](https://github.com/chapter-three/next-drupal/issues/547#issuecomment-1852673680)
