### PR TITLE
ci(next): add Drupal 10.2 to CI test matrix

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -13,13 +13,19 @@ jobs:
     strategy:
       matrix:
         # Supported PHP versions: https://www.drupal.org/docs/getting-started/system-requirements/php-requirements
-        php: ["8.1", "8.2", "8.3"]
+        php:
+          - "8.1"
+          - "8.2"
+          - "8.3"
         # Supported Drupal versions: https://www.drupal.org/project/drupal
-        drupal: ["10.0", "10.1"]
+        drupal:
+          - "10.0.x"
+          - "10.1.x"
+          - "10.2.x@RC"
         exclude:
-          - drupal: "10.0"
+          - drupal: "10.0.x"
             php: "8.3"
-          - drupal: "10.1"
+          - drupal: "10.1.x"
             php: "8.3"
     name: Drupal ${{ matrix.drupal }} - PHP ${{ matrix.php }}
     services:
@@ -53,7 +59,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
       - name: Setup Drupal
         run: |
-          COMPOSER_MEMORY_LIMIT=-1 composer create-project drupal/recommended-project:${{ matrix.drupal }}.x ~/drupal --no-interaction --no-install
+          COMPOSER_MEMORY_LIMIT=-1 composer create-project drupal/recommended-project:${{ matrix.drupal }} ~/drupal --no-interaction --no-install
           cd ~/drupal
           composer config extra.enable-patching true
           composer config extra.compile-mode all

--- a/modules/next/modules/next_jsonapi/tests/src/Kernel/Controller/EntityResourceTest.php
+++ b/modules/next/modules/next_jsonapi/tests/src/Kernel/Controller/EntityResourceTest.php
@@ -24,15 +24,16 @@ class EntityResourceTest extends KernelTestBase {
    * {@inheritdoc}
    */
   protected static $modules = [
+    'field',
+    'file',
     'filter',
+    'jsonapi',
     'next',
     'node',
-    'field',
-    'system',
-    'user',
-    'jsonapi',
     'path',
     'serialization',
+    'system',
+    'user',
   ];
 
   /**


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: #542

## Describe your changes

Runs the `next` module tests against Drupal 10.2.0-rc1
