### PR TITLE
Add public debug() method to DrupalClient

### DIFF
--- a/packages/next-drupal/src/client.ts
+++ b/packages/next-drupal/src/client.ts
@@ -77,9 +77,9 @@ function isClientIdSecretAuth(
 export class DrupalClient {
   baseUrl: BaseUrl
 
-  debug: DrupalClientOptions["debug"]
-
   frontPage: DrupalClientOptions["frontPage"]
+
+  private isDebugEnabled: DrupalClientOptions["debug"]
 
   private serializer: DrupalClientOptions["serializer"]
 
@@ -148,7 +148,7 @@ export class DrupalClient {
     this.apiPrefix = apiPrefix
     this.serializer = serializer
     this.frontPage = frontPage
-    this.debug = debug
+    this.isDebugEnabled = !!debug
     this.useDefaultResourceTypeEntry = useDefaultResourceTypeEntry
     this.fetcher = fetcher
     this.auth = auth
@@ -166,7 +166,7 @@ export class DrupalClient {
       this.throwJsonApiErrors = false
     }
 
-    this._debug("Debug mode is on.")
+    this.debug("Debug mode is on.")
   }
 
   set apiPrefix(apiPrefix: DrupalClientOptions["apiPrefix"]) {
@@ -228,7 +228,7 @@ export class DrupalClient {
     // Using the auth set on the client.
     // TODO: Abstract this to a re-usable.
     if (init?.withAuth) {
-      this._debug(`Using authenticated request.`)
+      this.debug(`Using authenticated request.`)
 
       if (init.withAuth === true) {
         if (typeof this._auth === "undefined") {
@@ -240,15 +240,15 @@ export class DrupalClient {
         // By default, if withAuth is set to true, we use the auth configured
         // in the client constructor.
         if (typeof this._auth === "function") {
-          this._debug(`Using custom auth callback.`)
+          this.debug(`Using custom auth callback.`)
 
           init["headers"]["Authorization"] = this._auth()
         } else if (typeof this._auth === "string") {
-          this._debug(`Using custom authorization header.`)
+          this.debug(`Using custom authorization header.`)
 
           init["headers"]["Authorization"] = this._auth
         } else if (typeof this._auth === "object") {
-          this._debug(`Using custom auth credentials.`)
+          this.debug(`Using custom auth credentials.`)
 
           if (isBasicAuth(this._auth)) {
             const basic = Buffer.from(
@@ -258,7 +258,7 @@ export class DrupalClient {
             init["headers"]["Authorization"] = `Basic ${basic}`
           } else if (isClientIdSecretAuth(this._auth)) {
             // Use the built-in client_credentials grant.
-            this._debug(`Using default auth (client_credentials).`)
+            this.debug(`Using default auth (client_credentials).`)
 
             // Fetch an access token and add it to the request.
             // Access token can be fetched from cache or using a custom auth method.
@@ -272,15 +272,15 @@ export class DrupalClient {
           }
         }
       } else if (typeof init.withAuth === "string") {
-        this._debug(`Using custom authorization header.`)
+        this.debug(`Using custom authorization header.`)
 
         init["headers"]["Authorization"] = init.withAuth
       } else if (typeof init.withAuth === "function") {
-        this._debug(`Using custom authorization callback.`)
+        this.debug(`Using custom authorization callback.`)
 
         init["headers"]["Authorization"] = init.withAuth()
       } else if (isBasicAuth(init.withAuth)) {
-        this._debug(`Using basic authorization header`)
+        this.debug(`Using basic authorization header.`)
 
         const basic = Buffer.from(
           `${init.withAuth.username}:${init.withAuth.password}`
@@ -301,12 +301,12 @@ export class DrupalClient {
     }
 
     if (this.fetcher) {
-      this._debug(`Using custom fetcher.`)
+      this.debug(`Using custom fetcher, fetching: ${input}`)
 
       return await this.fetcher(input, init)
     }
 
-    this._debug(`Using default fetch (polyfilled by Next.js).`)
+    this.debug(`Using default fetch, fetching: ${input}`)
 
     return await fetch(input, init)
   }
@@ -329,8 +329,7 @@ export class DrupalClient {
 
     const url = this.buildUrl(apiPath, options?.params)
 
-    this._debug(`Creating resource of type ${type}.`)
-    this._debug(url.toString())
+    this.debug(`Creating resource of type ${type}.`)
 
     // Add type to body.
     body.data.type = type
@@ -373,8 +372,7 @@ export class DrupalClient {
       options?.params
     )
 
-    this._debug(`Creating file resource for media of type ${type}.`)
-    this._debug(url.toString())
+    this.debug(`Creating file resource for media of type ${type}.`)
 
     const response = await this.fetch(url.toString(), {
       method: "POST",
@@ -415,8 +413,7 @@ export class DrupalClient {
 
     const url = this.buildUrl(`${apiPath}/${uuid}`, options?.params)
 
-    this._debug(`Updating resource of type ${type} with id ${uuid}.`)
-    this._debug(url.toString())
+    this.debug(`Updating resource of type ${type} with id ${uuid}.`)
 
     // Update body.
     body.data.type = type
@@ -455,8 +452,7 @@ export class DrupalClient {
 
     const url = this.buildUrl(`${apiPath}/${uuid}`, options?.params)
 
-    this._debug(`Deleting resource of type ${type} with id ${uuid}.`)
-    this._debug(url.toString())
+    this.debug(`Deleting resource of type ${type} with id ${uuid}.`)
 
     const response = await this.fetch(url.toString(), {
       method: "DELETE",
@@ -489,7 +485,7 @@ export class DrupalClient {
       const cached = (await this.cache.get(options.cacheKey)) as string
 
       if (cached) {
-        this._debug(`Returning cached resource ${type} with id ${uuid}`)
+        this.debug(`Returning cached resource ${type} with id ${uuid}.`)
 
         const json = JSON.parse(cached)
 
@@ -504,8 +500,7 @@ export class DrupalClient {
 
     const url = this.buildUrl(`${apiPath}/${uuid}`, options?.params)
 
-    this._debug(`Fetching resource ${type} with id ${uuid}.`)
-    this._debug(url.toString())
+    this.debug(`Fetching resource ${type} with id ${uuid}.`)
 
     const response = await this.fetch(url.toString(), {
       withAuth: options.withAuth,
@@ -687,6 +682,8 @@ export class DrupalClient {
       _format: "json",
     })
 
+    this.debug(`Fetching resource by path, ${path}.`)
+
     const response = await this.fetch(url.toString(), {
       method: "POST",
       credentials: "include",
@@ -739,8 +736,7 @@ export class DrupalClient {
       ...options?.params,
     })
 
-    this._debug(`Fetching resource collection of type ${type}`)
-    this._debug(url.toString())
+    this.debug(`Fetching resource collection of type ${type}.`)
 
     const response = await this.fetch(url.toString(), {
       withAuth: options.withAuth,
@@ -910,6 +906,8 @@ export class DrupalClient {
       path,
     })
 
+    this.debug(`Fetching translated path, ${path}.`)
+
     const response = await this.fetch(url.toString(), {
       withAuth: options.withAuth,
     })
@@ -990,6 +988,8 @@ export class DrupalClient {
     )
 
     try {
+      this.debug(`Fetching JSON:API index.`)
+
       const response = await this.fetch(url.toString(), {
         // As per https://www.drupal.org/node/2984034 /jsonapi is public.
         withAuth: false,
@@ -1123,7 +1123,7 @@ export class DrupalClient {
       const cached = (await this.cache.get(options.cacheKey)) as string
 
       if (cached) {
-        this._debug(`Returning cached menu items for ${name}`)
+        this.debug(`Returning cached menu items for ${name}.`)
         return JSON.parse(cached)
       }
     }
@@ -1138,8 +1138,7 @@ export class DrupalClient {
       options.params
     )
 
-    this._debug(`Fetching menu items for ${name}.`)
-    this._debug(url.toString())
+    this.debug(`Fetching menu items for ${name}.`)
 
     const response = await this.fetch(url.toString(), {
       withAuth: options.withAuth,
@@ -1212,6 +1211,8 @@ export class DrupalClient {
       options.params
     )
 
+    this.debug(`Fetching view, ${viewId}.${displayId}.`)
+
     const response = await this.fetch(url.toString(), {
       withAuth: options.withAuth,
     })
@@ -1251,6 +1252,8 @@ export class DrupalClient {
       `${localePrefix}${this.apiPrefix}/index/${name}`,
       options.params
     )
+
+    this.debug(`Fetching search index, ${name}.`)
 
     const response = await this.fetch(url.toString(), {
       withAuth: options.withAuth,
@@ -1330,11 +1333,11 @@ export class DrupalClient {
       this._token &&
       Date.now() < this.tokenExpiresOn
     ) {
-      this._debug(`Using existing access token.`)
+      this.debug(`Using existing access token.`)
       return this._token
     }
 
-    this._debug(`Fetching new access token.`)
+    this.debug(`Fetching new access token.`)
 
     const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64")
 
@@ -1343,7 +1346,7 @@ export class DrupalClient {
     if (opts?.scope) {
       body = `${body}&scope=${opts.scope}`
 
-      this._debug(`Using scope: ${opts.scope}`)
+      this.debug(`Using scope: ${opts.scope}`)
     }
 
     const response = await this.fetch(url.toString(), {
@@ -1361,8 +1364,6 @@ export class DrupalClient {
     }
 
     const result: AccessToken = await response.json()
-
-    this._debug(result)
 
     this.token = result
 
@@ -1411,8 +1412,8 @@ export class DrupalClient {
     return message
   }
 
-  private _debug(message) {
-    !!this.debug && this.logger.debug(message)
+  debug(message) {
+    this.isDebugEnabled && this.logger.debug(message)
   }
 
   // Error handling.

--- a/packages/next-drupal/src/client.ts
+++ b/packages/next-drupal/src/client.ts
@@ -215,7 +215,6 @@ export class DrupalClient {
     this.tokenExpiresOn = Date.now() + token.expires_in * 1000
   }
 
-  /* eslint-disable @typescript-eslint/no-explicit-any */
   async fetch(input: RequestInfo, init?: FetchOptions): Promise<Response> {
     init = {
       ...init,
@@ -268,9 +267,8 @@ export class DrupalClient {
               init["headers"]["Authorization"] = `Bearer ${token.access_token}`
             }
           } else if (isAccessTokenAuth(this._auth)) {
-            init["headers"][
-              "Authorization"
-            ] = `${this._auth.token_type} ${this._auth.access_token}`
+            init["headers"]["Authorization"] =
+              `${this._auth.token_type} ${this._auth.access_token}`
           }
         }
       } else if (typeof init.withAuth === "string") {
@@ -297,9 +295,8 @@ export class DrupalClient {
           init["headers"]["Authorization"] = `Bearer ${token.access_token}`
         }
       } else if (isAccessTokenAuth(init.withAuth)) {
-        init["headers"][
-          "Authorization"
-        ] = `${init.withAuth.token_type} ${init.withAuth.access_token}`
+        init["headers"]["Authorization"] =
+          `${init.withAuth.token_type} ${init.withAuth.access_token}`
       }
     }
 
@@ -1419,8 +1416,8 @@ export class DrupalClient {
   }
 
   // Error handling.
-  // If throwErrors is enable, we show errors in the Next.js overlay.
-  // Otherwise we log the errors even if debugging is turned off.
+  // If throwErrors is enabled, we show errors in the Next.js overlay.
+  // Otherwise, we log the errors even if debugging is turned off.
   // In production, errors are always logged never thrown.
   private throwError(error: Error) {
     if (!this.throwJsonApiErrors) {

--- a/packages/next-drupal/src/logger.ts
+++ b/packages/next-drupal/src/logger.ts
@@ -1,17 +1,22 @@
 import type { Logger } from "./types"
 
+export const LOG_MESSAGE_PREFIX = "[next-drupal][log]:"
+export const DEBUG_MESSAGE_PREFIX = "[next-drupal][debug]:"
+export const WARN_MESSAGE_PREFIX = "[next-drupal][warn]:"
+export const ERROR_MESSAGE_PREFIX = "[next-drupal][error]:"
+
 // Default logger. Uses console.
 export const logger: Logger = {
   log(message) {
-    console.log(`[next-drupal][log]:`, message)
+    console.log(LOG_MESSAGE_PREFIX, message)
   },
   debug(message) {
-    console.debug(`[next-drupal][debug]:`, message)
+    console.debug(DEBUG_MESSAGE_PREFIX, message)
   },
   warn(message) {
-    console.warn(`[next-drupal][debug]:`, message)
+    console.warn(WARN_MESSAGE_PREFIX, message)
   },
   error(message) {
-    console.error(`[next-drupal][error]:`, message)
+    console.error(ERROR_MESSAGE_PREFIX, message)
   },
 }

--- a/packages/next-drupal/src/utils.ts
+++ b/packages/next-drupal/src/utils.ts
@@ -89,9 +89,8 @@ export async function buildHeaders({
   // This reduces the number of OAuth call to the Drupal server.
   // Intentionally marked as unstable for now.
   if (process.env.UNSTABLE_DRUPAL_ACCESS_TOKEN) {
-    headers[
-      "Authorization"
-    ] = `Bearer ${process.env.UNSTABLE_DRUPAL_ACCESS_TOKEN}`
+    headers["Authorization"] =
+      `Bearer ${process.env.UNSTABLE_DRUPAL_ACCESS_TOKEN}`
 
     return headers
   }
@@ -122,8 +121,8 @@ export function getPathFromContext(
   return !slug
     ? process.env.DRUPAL_FRONT_PAGE
     : prefix
-    ? `${prefix}/${slug}`
-    : slug
+      ? `${prefix}/${slug}`
+      : slug
 }
 
 export function syncDrupalPreviewRoutes(path) {

--- a/packages/next-drupal/tests/client.test.ts
+++ b/packages/next-drupal/tests/client.test.ts
@@ -59,7 +59,7 @@ describe("DrupalClient", () => {
       "[next-drupal][debug]:",
       "Debug mode is on."
     )
-    expect(client.debug).toBe(true)
+    expect(client.isDebugEnabled).toBe(true)
   })
 })
 


### PR DESCRIPTION
This pull request is for:
- [x] `packages/next-drupal`

GitHub Issue: #668

## Describe your changes

In the `DrupalClient`, this changes the internal `_debug()` method to a public `debug()` method. It also changes a previously public `debug` property (boolean) to an internal property.

This PR also fixes some code formatting in the first commit.