### PR TITLE
Fix error on entity canonical page when there is no site resolver.

### DIFF
--- a/modules/next/src/Render/MainContent/HtmlRenderer.php
+++ b/modules/next/src/Render/MainContent/HtmlRenderer.php
@@ -112,8 +112,8 @@ class HtmlRenderer extends CoreHtmlRenderer {
       return $build;
     }
 
-    $sites = $next_entity_type_config->getSiteResolver()->getSitesForEntity($entity);
-    if (!count($sites)) {
+    $sites = $next_entity_type_config->getSiteResolver()?->getSitesForEntity($entity);
+    if (!$sites) {
       return $build;
     }
 


### PR DESCRIPTION
This pull request is for:

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: #517 

## Describe your changes

As mentioned in #517, if you have an entity type configured that _does not_ have a site resolver (or from the UI perspective, preview mode set to None), you get the following error on the canonical entity page:
```
Call to a member function getSitesForEntity() on null in Drupal\next\Render\MainContent\HtmlRenderer->prepare()
```

This is because `HtmlRenderer` assumes `getSiteResolver()` returns a `SiteResolverInterface` despite the signature (supported by the UI where you can select none) being:
```
public function getSiteResolver(): ?SiteResolverInterface;
```

This PR uses a null object accessor and switches to a falsy (empty array or null) check on the result.
