### PR TITLE
#527 - Ensure offset is respected in JSON:API.

### DIFF
--- a/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
+++ b/modules/next/modules/next_jsonapi/src/Controller/EntityResource.php
@@ -100,7 +100,7 @@ class EntityResource extends JsonApiEntityResource {
       $max = $page['limit'];
     }
 
-    $params[OffsetPage::KEY_NAME] = new OffsetPage(OffsetPage::DEFAULT_OFFSET, $max);
+    $params[OffsetPage::KEY_NAME] = new OffsetPage($query['offset'] ?? OffsetPage::DEFAULT_OFFSET, $max);
 
     return $params;
   }


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: #527

- [x] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

I've had an issue where we could not build more than 1000 pages in a sitemap in nextjs because we could not paginate JSON:API beyond that point. This seems to be because of this issue.
