### PR TITLE
ci(next-drupal): run code formatting/linting on full monorepo

### DIFF
--- a/.github/workflows/next-drupal.yml
+++ b/.github/workflows/next-drupal.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - name: Install modules
+      - name: Install packages
         run: yarn
       - name: Run tests
-        run: yarn workspace next-drupal test
+        run: yarn test
         env:
           DRUPAL_BASE_URL: ${{ secrets.DRUPAL_BASE_URL }}
           DRUPAL_USERNAME: ${{ secrets.DRUPAL_USERNAME }}

--- a/examples/example-blog/components/meta.tsx
+++ b/examples/example-blog/components/meta.tsx
@@ -48,7 +48,11 @@ export function Meta({ title, tags }: MetaProps) {
             content={`${process.env.NEXT_PUBLIC_BASE_URL}/images/meta.jpg`}
           />
           <meta key="og_image_width" property="og:image:width" content="800" />
-          <meta key="og_image_height" property="og:image:height" content="600" />
+          <meta
+            key="og_image_height"
+            property="og:image:height"
+            content="600"
+          />
         </>
       )}
     </Head>

--- a/examples/example-graphql/pages/[...slug].tsx
+++ b/examples/example-graphql/pages/[...slug].tsx
@@ -12,7 +12,11 @@ export default function NodePage({ resource }) {
     <Layout>
       <Head>
         <title>{resource.title}</title>
-        <meta key="description" name="description" content="A Next.js site powered by Drupal." />
+        <meta
+          key="description"
+          name="description"
+          content="A Next.js site powered by Drupal."
+        />
       </Head>
       {resource && <NodeArticle node={resource} />}
     </Layout>

--- a/examples/example-marketing/components/meta.tsx
+++ b/examples/example-marketing/components/meta.tsx
@@ -48,7 +48,11 @@ export function Meta({ title, tags }: MetaProps) {
             content={`${process.env.NEXT_PUBLIC_BASE_URL}/images/meta.jpg`}
           />
           <meta key="og_image_width" property="og:image:width" content="800" />
-          <meta key="og_image_height" property="og:image:height" content="600" />
+          <meta
+            key="og_image_height"
+            property="og:image:height"
+            content="600"
+          />
         </>
       )}
     </Head>

--- a/examples/example-umami/components/meta.tsx
+++ b/examples/example-umami/components/meta.tsx
@@ -21,7 +21,11 @@ export function Meta({ title, description }: MetaProps) {
         href={absoluteURL(router.asPath !== "/" ? router.asPath : "")}
       />
       <title>{`${title} | ${siteConfig.name}`}</title>
-      <meta key="description" name="description" content={description || siteConfig.slogan} />
+      <meta
+        key="description"
+        name="description"
+        content={description || siteConfig.slogan}
+      />
       <meta
         key="og_image"
         property="og:image"


### PR DESCRIPTION
This pull request is for:

- [x] Other

GitHub Issue: #700

## Describe your changes

Runs tests across entire monorepo instead of just in packages/next-drupal and modules/next