### PR TITLE
Replace "slug" with "path" in draft/revalidate URLs

### DIFF
--- a/examples/example-graphql/pages/api/revalidate.ts
+++ b/examples/example-graphql/pages/api/revalidate.ts
@@ -4,7 +4,7 @@ export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ) {
-  let slug = request.query.slug as string
+  let path = request.query.path as string
   const secret = request.query.secret as string
 
   // Validate secret.
@@ -12,13 +12,13 @@ export default async function handler(
     return response.status(401).json({ message: "Invalid secret." })
   }
 
-  // Validate slug.
-  if (!slug) {
-    return response.status(400).json({ message: "Invalid slug." })
+  // Validate path.
+  if (!path) {
+    return response.status(400).json({ message: "Invalid path." })
   }
 
   try {
-    await response.revalidate(slug)
+    await response.revalidate(path)
 
     return response.json({})
   } catch (error) {

--- a/examples/example-marketing/pages/api/revalidate.ts
+++ b/examples/example-marketing/pages/api/revalidate.ts
@@ -4,7 +4,7 @@ export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ) {
-  let slug = request.query.slug as string
+  let path = request.query.path as string
   const secret = request.query.secret as string
 
   // Validate secret.
@@ -12,18 +12,18 @@ export default async function handler(
     return response.status(401).json({ message: "Invalid secret." })
   }
 
-  // Validate slug.
-  if (!slug) {
-    return response.status(400).json({ message: "Invalid slug." })
+  // Validate path.
+  if (!path) {
+    return response.status(400).json({ message: "Invalid path." })
   }
 
-  // Fix for home slug.
-  if (slug === process.env.DRUPAL_FRONT_PAGE) {
-    slug = "/"
+  // Fix for homepage.
+  if (path === process.env.DRUPAL_FRONT_PAGE) {
+    path = "/"
   }
 
   try {
-    await response.revalidate(slug)
+    await response.revalidate(path)
 
     return response.json({})
   } catch (error) {

--- a/examples/example-router-migration/app/[...slug]/page.tsx
+++ b/examples/example-router-migration/app/[...slug]/page.tsx
@@ -8,13 +8,13 @@ import type { Metadata, ResolvingMetadata } from "next"
 import type { DrupalNode, JsonApiParams } from "next-drupal"
 
 async function getNode(slug: string[]) {
-  const path = slug.join("/")
+  const path = `/${slug.join("/")}`
 
   const params: JsonApiParams = {}
 
   const draftData = getDraftData()
 
-  if (draftData.slug === `/${path}`) {
+  if (draftData.path === path) {
     params.resourceVersion = draftData.resourceVersion
   }
 

--- a/examples/example-router-migration/app/api/revalidate/route.ts
+++ b/examples/example-router-migration/app/api/revalidate/route.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server"
 
 async function handler(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams
-  const slug = searchParams.get("slug")
+  const path = searchParams.get("path")
   const secret = searchParams.get("secret")
 
   // Validate secret.
@@ -11,13 +11,13 @@ async function handler(request: NextRequest) {
     return new Response("Invalid secret.", { status: 401 })
   }
 
-  // Validate slug.
-  if (!slug) {
-    return new Response("Invalid slug.", { status: 400 })
+  // Validate path.
+  if (!path) {
+    return new Response("Invalid path.", { status: 400 })
   }
 
   try {
-    revalidatePath(slug)
+    revalidatePath(path)
 
     return new Response("Revalidated.")
   } catch (error) {

--- a/modules/next/modules/next_extras/src/NextCacheInvalidator.php
+++ b/modules/next/modules/next_extras/src/NextCacheInvalidator.php
@@ -164,7 +164,7 @@ class NextCacheInvalidator {
     return Url::fromUri("{$site->getBaseUrl()}/api/revalidate", [
       'query' => [
         'secret' => $site->getPreviewSecret(),
-        'slug' => $path,
+        'path' => $path,
       ],
     ])->toString();
   }

--- a/modules/next/modules/next_jwt/src/Plugin/Next/PreviewUrlGenerator/Jwt.php
+++ b/modules/next/modules/next_jwt/src/Plugin/Next/PreviewUrlGenerator/Jwt.php
@@ -134,12 +134,12 @@ class Jwt extends ConfigurablePreviewUrlGeneratorBase {
    */
   public function generate(NextSiteInterface $next_site, EntityInterface $entity, string $resource_version = NULL): ?Url {
     $query = [];
-    $query['slug'] = $slug = $entity->toUrl()->toString();
+    $query['path'] = $path = $entity->toUrl()->toString();
     $query['uuid'] = $this->user->uuid();
 
-    // Create a secret based on the timestamp, slug and the user uuid.
+    // Create a secret based on the timestamp, path and the user uuid.
     $query['timestamp'] = $timestamp = $this->time->getRequestTime();
-    $query['secret'] = $secret = $this->previewSecretGenerator->generate($timestamp . $slug . $resource_version . $this->user->uuid());
+    $query['secret'] = $secret = $this->previewSecretGenerator->generate($timestamp . $path . $resource_version . $this->user->uuid());
 
     // Generate a JWT and store it temporarily so that we can retrieve it on
     // validate.
@@ -158,10 +158,10 @@ class Jwt extends ConfigurablePreviewUrlGeneratorBase {
   public function validate(Request $request) {
     $body = Json::decode($request->getContent());
 
-    // Validate the slug.
-    // We do not check for existing slug. We let the next.js site handle this.
-    if (empty($body['slug'])) {
-      throw new InvalidPreviewUrlRequest("Field 'slug' is missing");
+    // Validate the path.
+    // We do not check for existing path. We let the next.js site handle this.
+    if (empty($body['path'])) {
+      throw new InvalidPreviewUrlRequest("Field 'path' is missing");
     }
 
     // Validate the uuid.
@@ -184,7 +184,7 @@ class Jwt extends ConfigurablePreviewUrlGeneratorBase {
       throw new InvalidPreviewUrlRequest("Field 'secret' is missing");
     }
 
-    if ($body['secret'] !== $this->previewSecretGenerator->generate($body['timestamp'] . $body['slug'] . $body['resourceVersion'] . $body['uuid'])) {
+    if ($body['secret'] !== $this->previewSecretGenerator->generate($body['timestamp'] . $body['path'] . $body['resourceVersion'] . $body['uuid'])) {
       throw new InvalidPreviewUrlRequest("The provided secret is invalid.");
     }
 

--- a/modules/next/src/Entity/NextSite.php
+++ b/modules/next/src/Entity/NextSite.php
@@ -273,7 +273,7 @@ class NextSite extends ConfigEntityBase implements NextSiteInterface {
     }
 
     $query = [
-      'slug' => $path,
+      'path' => $path,
     ];
 
     if ($secret = $this->getRevalidateSecret()) {

--- a/modules/next/src/Plugin/Next/PreviewUrlGenerator/SimpleOauth.php
+++ b/modules/next/src/Plugin/Next/PreviewUrlGenerator/SimpleOauth.php
@@ -126,11 +126,11 @@ class SimpleOauth extends ConfigurablePreviewUrlGeneratorBase {
    */
   public function generate(NextSiteInterface $next_site, EntityInterface $entity, string $resource_version = NULL): ?Url {
     $query = [];
-    $query['slug'] = $slug = $entity->toUrl()->toString();
+    $query['path'] = $path = $entity->toUrl()->toString();
 
-    // Create a secret based on the timestamp, slug, scope and resource version.
+    // Create a secret based on the timestamp, path, scope and resource version.
     $query['timestamp'] = $timestamp = $this->time->getRequestTime();
-    $query['secret'] = $this->previewSecretGenerator->generate($timestamp . $slug . $resource_version);
+    $query['secret'] = $this->previewSecretGenerator->generate($timestamp . $path . $resource_version);
 
     return Url::fromUri($next_site->getPreviewUrl(), [
       'query' => $query,
@@ -143,10 +143,10 @@ class SimpleOauth extends ConfigurablePreviewUrlGeneratorBase {
   public function validate(Request $request) {
     $body = Json::decode($request->getContent());
 
-    // Validate the slug.
-    // We do not check for existing slug. We let the next.js site handle this.
-    if (empty($body['slug'])) {
-      throw new InvalidPreviewUrlRequest("Field 'slug' is missing");
+    // Validate the path.
+    // We do not check for existing path. We let the next.js site handle this.
+    if (empty($body['path'])) {
+      throw new InvalidPreviewUrlRequest("Field 'path' is missing");
     }
 
     // Validate the timestamp.
@@ -164,12 +164,12 @@ class SimpleOauth extends ConfigurablePreviewUrlGeneratorBase {
       throw new InvalidPreviewUrlRequest("Field 'secret' is missing");
     }
 
-    if ($body['secret'] !== $this->previewSecretGenerator->generate($body['timestamp'] . $body['slug'] . $body['resourceVersion'])) {
+    if ($body['secret'] !== $this->previewSecretGenerator->generate($body['timestamp'] . $body['path'] . $body['resourceVersion'])) {
       throw new InvalidPreviewUrlRequest("The provided secret is invalid.");
     }
 
     return [
-      'path' => $body['slug'],
+      'path' => $body['path'],
       'maxAge' => (int) $this->configuration['secret_expiration'],
     ];
   }

--- a/modules/next/tests/src/Kernel/Entity/NextSiteTest.php
+++ b/modules/next/tests/src/Kernel/Entity/NextSiteTest.php
@@ -133,10 +133,10 @@ class NextSiteTest extends KernelTestBase {
     $this->assertNull($marketing->getRevalidateUrlForPath('/foo'));
 
     $marketing->setRevalidateUrl('http://example.com/api/revalidate');
-    $this->assertSame('http://example.com/api/revalidate?slug=/foo', $marketing->getRevalidateUrlForPath('/foo')->toString());
+    $this->assertSame('http://example.com/api/revalidate?path=/foo', $marketing->getRevalidateUrlForPath('/foo')->toString());
 
     $marketing->setRevalidateSecret('12345');
-    $this->assertSame('http://example.com/api/revalidate?slug=/foo&secret=12345', $marketing->getRevalidateUrlForPath('/foo')->toString());
+    $this->assertSame('http://example.com/api/revalidate?path=/foo&secret=12345', $marketing->getRevalidateUrlForPath('/foo')->toString());
   }
 
 }

--- a/modules/next/tests/src/Kernel/Plugin/PathRevalidatorTest.php
+++ b/modules/next/tests/src/Kernel/Plugin/PathRevalidatorTest.php
@@ -85,7 +85,7 @@ class PathRevalidatorTest extends KernelTestBase {
     $page->save();
     $this->container->get('kernel')->terminate(Request::create('/'), new Response());
 
-    $client->request('GET', 'http://blog.com/api/revalidate?slug=/node/2')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://blog.com/api/revalidate?path=/node/2')->shouldBeCalled()->willReturn(new GuzzleResponse());
     $blog_site->setRevalidateUrl('http://blog.com/api/revalidate')->save();
     $page = $this->createNode();
     $page->save();
@@ -104,8 +104,8 @@ class PathRevalidatorTest extends KernelTestBase {
       ],
     ])->save();
 
-    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/node/3&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
-    $client->request('GET', 'http://blog.com/api/revalidate?slug=/node/3')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://marketing.com/api/revalidate?path=/node/3&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://blog.com/api/revalidate?path=/node/3')->shouldBeCalled()->willReturn(new GuzzleResponse());
     $page = $this->createNode();
     $page->save();
     $this->container->get('kernel')->terminate(Request::create('/'), new Response());
@@ -114,12 +114,12 @@ class PathRevalidatorTest extends KernelTestBase {
       'additional_paths' => "/\n/blog",
     ])->save();
 
-    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/node/3&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
-    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
-    $client->request('GET', 'http://marketing.com/api/revalidate?slug=/blog&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
-    $client->request('GET', 'http://blog.com/api/revalidate?slug=/node/3')->shouldBeCalled()->willReturn(new GuzzleResponse());
-    $client->request('GET', 'http://blog.com/api/revalidate?slug=/')->shouldBeCalled()->willReturn(new GuzzleResponse());
-    $client->request('GET', 'http://blog.com/api/revalidate?slug=/blog')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://marketing.com/api/revalidate?path=/node/3&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://marketing.com/api/revalidate?path=/&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://marketing.com/api/revalidate?path=/blog&secret=12345')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://blog.com/api/revalidate?path=/node/3')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://blog.com/api/revalidate?path=/')->shouldBeCalled()->willReturn(new GuzzleResponse());
+    $client->request('GET', 'http://blog.com/api/revalidate?path=/blog')->shouldBeCalled()->willReturn(new GuzzleResponse());
     $page = $this->createNode();
     $page->save();
     $this->container->get('kernel')->terminate(Request::create('/'), new Response());

--- a/modules/next/tests/src/Kernel/Plugin/SimpleOauthPreviewUrlGeneratorTest.php
+++ b/modules/next/tests/src/Kernel/Plugin/SimpleOauthPreviewUrlGeneratorTest.php
@@ -96,7 +96,7 @@ class SimpleOauthPreviewUrlGeneratorTest extends KernelTestBase {
     $this->setCurrentUser($user);
     $preview_url = $this->nextSite->getPreviewUrlForEntity($page);
     $query = $preview_url->getOption('query');
-    $this->assertNotEmpty($query['slug']);
+    $this->assertNotEmpty($query['path']);
     $this->assertNotEmpty($query['timestamp']);
     $this->assertNotEmpty($query['secret']);
     $this->assertSame($query['plugin'], 'simple_oauth');
@@ -104,7 +104,7 @@ class SimpleOauthPreviewUrlGeneratorTest extends KernelTestBase {
     // Test the secret.
     /** @var \Drupal\next\PreviewSecretGeneratorInterface $secret_generator */
     $secret_generator = \Drupal::service('next.preview_secret_generator');
-    $this->assertSame($query['secret'], $secret_generator->generate($query['timestamp'] . $query['slug'] . $query['resourceVersion']));
+    $this->assertSame($query['secret'], $secret_generator->generate($query['timestamp'] . $query['path'] . $query['resourceVersion']));
   }
 
   /**
@@ -143,7 +143,7 @@ class SimpleOauthPreviewUrlGeneratorTest extends KernelTestBase {
 
     $this->expectExceptionMessage('The provided secret is invalid.');
     $query = $preview_url->getOption('query');
-    $query['slug'] = '/random-slug';
+    $query['path'] = '/random-path';
     $request = Request::create('/', 'POST', [], [], [], [], Json::encode($query));
     $preview_url_generator->validate($request);
 
@@ -162,18 +162,18 @@ class SimpleOauthPreviewUrlGeneratorTest extends KernelTestBase {
    */
   public function providerValidateForInvalidBody() {
     return [
-      [[], "Field 'slug' is missing"],
-      [['slug' => '/node/1'], "Field 'timestamp' is missing"],
+      [[], "Field 'path' is missing"],
+      [['path' => '/node/1'], "Field 'timestamp' is missing"],
       [
         [
-          'slug' => '/node/1',
+          'path' => '/node/1',
           'timestamp' => strtotime('now'),
         ],
         "Field 'secret' is missing",
       ],
       [
         [
-          'slug' => '/node/1',
+          'path' => '/node/1',
           'timestamp' => strtotime('-60 seconds'),
           'secret' => 'secret',
         ],
@@ -181,7 +181,7 @@ class SimpleOauthPreviewUrlGeneratorTest extends KernelTestBase {
       ],
       [
         [
-          'slug' => '/node/1',
+          'path' => '/node/1',
           'timestamp' => strtotime('60 seconds'),
           'secret' => 'secret',
         ],

--- a/modules/next/tests/src/Kernel/Renderer/MainContent/HtmlRendererTest.php
+++ b/modules/next/tests/src/Kernel/Renderer/MainContent/HtmlRendererTest.php
@@ -88,7 +88,7 @@ class HtmlRendererTest extends KernelTestBase {
     $response = $this->container->get('http_kernel')->handle($request);
     $this->setRawContent($response->getContent());
 
-    $preview_url = 'https://blog.com/api/preview?slug=/node/1';
+    $preview_url = 'https://blog.com/api/preview?path=/node/1';
     $fields = $this->xpath("//iframe[contains(@src, '$preview_url')]");
     $this->assertCount(1, $fields);
 

--- a/packages/next-drupal/src/client.ts
+++ b/packages/next-drupal/src/client.ts
@@ -1023,11 +1023,11 @@ export class DrupalClient {
   }
 
   async validateDraftUrl(searchParams: URLSearchParams): Promise<Response> {
-    const slug = searchParams.get("slug")
+    const path = searchParams.get("path")
 
-    this.debug(`Fetching draft url validation for ${slug}.`)
+    this.debug(`Fetching draft url validation for ${path}.`)
 
-    // Fetch the headless CMS to check if the provided `slug` exists
+    // Fetch the headless CMS to check if the provided `path` exists
     let response: Response
     try {
       // Validate the draft url.
@@ -1047,8 +1047,8 @@ export class DrupalClient {
 
     this.debug(
       response.status !== 200
-        ? `Could not validate slug, ${slug}`
-        : `Validated slug, ${slug}`
+        ? `Could not validate path, ${path}`
+        : `Validated path, ${path}`
     )
 
     return response
@@ -1060,7 +1060,7 @@ export class DrupalClient {
     options?: Parameters<NextApiResponse["setDraftMode"]>[0]
   ) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { slug, resourceVersion, plugin, secret, scope, ...draftData } =
+    const { path, resourceVersion, plugin, secret, scope, ...draftData } =
       request.query
     const useDraftMode = options?.enable
 
@@ -1104,15 +1104,15 @@ export class DrupalClient {
         // Adds preview data for use in app router pages.
         cookies.push(
           `${DRAFT_DATA_COOKIE_NAME}=${encodeURIComponent(
-            JSON.stringify({ slug, resourceVersion, ...draftData })
+            JSON.stringify({ path, resourceVersion, ...draftData })
           )}; Path=/; HttpOnly; SameSite=None; Secure`
         )
       }
       response.setHeader("Set-Cookie", cookies)
 
-      // We can safely redirect to the slug since this has been validated on the
+      // We can safely redirect to the path since this has been validated on the
       // server.
-      response.writeHead(307, { Location: slug })
+      response.writeHead(307, { Location: path })
 
       this.debug(`${useDraftMode ? "Draft" : "Preview"} mode enabled.`)
 

--- a/packages/next-drupal/src/deprecated/preview.ts
+++ b/packages/next-drupal/src/deprecated/preview.ts
@@ -18,7 +18,7 @@ export async function PreviewHandler(
   response?: NextApiResponse,
   options?: PreviewOptions
 ) {
-  const { slug, resourceVersion, secret, locale, defaultLocale } = request.query
+  const { path, resourceVersion, secret, locale, defaultLocale } = request.query
 
   if (secret !== process.env.DRUPAL_PREVIEW_SECRET) {
     return response.status(401).json({
@@ -26,7 +26,7 @@ export async function PreviewHandler(
     })
   }
 
-  if (!slug) {
+  if (!path) {
     return response
       .status(401)
       .end({ message: options?.errorMessages.slug || "Invalid slug." })
@@ -43,7 +43,7 @@ export async function PreviewHandler(
     }
   }
 
-  const url = await getResourcePreviewUrl(slug as string, _options)
+  const url = await getResourcePreviewUrl(path as string, _options)
 
   if (!url) {
     response

--- a/packages/next-drupal/src/draft.ts
+++ b/packages/next-drupal/src/draft.ts
@@ -17,7 +17,7 @@ export async function enableDraftMode(
   }
 
   const searchParams = request.nextUrl.searchParams
-  const slug = searchParams.get("slug")
+  const path = searchParams.get("path")
 
   // Enable Draft Mode by setting the cookie
   draftMode().enable()
@@ -47,8 +47,8 @@ export async function enableDraftMode(
   })
 
   // Redirect to the path from the fetched post. We can safely redirect to the
-  // slug since this has been validated on the server.
-  redirect(slug)
+  // path since this has been validated on the server.
+  redirect(path)
 }
 
 export function disableDraftMode() {
@@ -59,7 +59,7 @@ export function disableDraftMode() {
 }
 
 export interface DraftData {
-  slug?: string
+  path?: string
   resourceVersion?: string
 }
 

--- a/packages/next-drupal/tests/DrupalClient/basic-methods.test.ts
+++ b/packages/next-drupal/tests/DrupalClient/basic-methods.test.ts
@@ -311,9 +311,9 @@ describe("validateDraftUrl()", () => {
       debug: true,
       logger,
     })
-    const slug = "/example"
+    const path = "/example"
     const searchParams = new URLSearchParams({
-      slug,
+      path,
     })
 
     const testPayload = { test: "resolved" }
@@ -331,21 +331,21 @@ describe("validateDraftUrl()", () => {
     expect(response.status).toBe(200)
     expect(logger.debug).toHaveBeenCalledWith("Debug mode is on.")
     expect(logger.debug).toHaveBeenCalledWith(
-      `Fetching draft url validation for ${slug}.`
+      `Fetching draft url validation for ${path}.`
     )
-    expect(logger.debug).toHaveBeenCalledWith(`Validated slug, ${slug}`)
+    expect(logger.debug).toHaveBeenCalledWith(`Validated path, ${path}`)
 
     response = await client.validateDraftUrl(searchParams)
     expect(response.status).toBe(404)
     expect(logger.debug).toHaveBeenCalledWith(
-      `Could not validate slug, ${slug}`
+      `Could not validate path, ${path}`
     )
   })
 
   test("calls draft-url endpoint", async () => {
     const client = new DrupalClient(BASE_URL)
     const searchParams = new URLSearchParams({
-      slug: "/example",
+      path: "/example",
     })
 
     const testPayload = { test: "resolved" }
@@ -370,7 +370,7 @@ describe("validateDraftUrl()", () => {
   test("returns a response object on success", async () => {
     const client = new DrupalClient(BASE_URL)
     const searchParams = new URLSearchParams({
-      slug: "/example",
+      path: "/example",
     })
 
     const testPayload = { test: "resolved" }
@@ -386,7 +386,7 @@ describe("validateDraftUrl()", () => {
   test("returns a response if fetch throws", async () => {
     const client = new DrupalClient(BASE_URL)
     const searchParams = new URLSearchParams({
-      slug: "/example",
+      path: "/example",
     })
 
     const message = "random fetch error"

--- a/packages/next-drupal/tests/DrupalClient/pages-router-methods.test.ts
+++ b/packages/next-drupal/tests/DrupalClient/pages-router-methods.test.ts
@@ -1179,13 +1179,13 @@ describe("getStaticPathsFromContext()", () => {
 describe("preview()", () => {
   // Get values from our mocked request.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { slug, resourceVersion, plugin, secret, ...draftData } =
+  const { path, resourceVersion, plugin, secret, ...draftData } =
     new NextApiRequest().query
   const dataCookie = `${DRAFT_DATA_COOKIE_NAME}=${encodeURIComponent(
-    JSON.stringify({ slug, resourceVersion, ...draftData })
+    JSON.stringify({ path, resourceVersion, ...draftData })
   )}; Path=/; HttpOnly; SameSite=None; Secure`
   const validationPayload = {
-    slug,
+    path,
     maxAge: 30,
   }
 
@@ -1291,7 +1291,7 @@ describe("preview()", () => {
     expect(response.getHeader("Set-Cookie")).toStrictEqual(cookies)
   })
 
-  test("redirects to the slug path", async () => {
+  test("redirects to the given path", async () => {
     const request = new NextApiRequest()
     const response = new NextApiResponse()
     const logger = mockLogger()
@@ -1305,7 +1305,7 @@ describe("preview()", () => {
       plugin,
       ...validationPayload,
     })
-    expect(response.writeHead).toBeCalledWith(307, { Location: slug })
+    expect(response.writeHead).toBeCalledWith(307, { Location: path })
     expect(logger.debug).toHaveBeenLastCalledWith("Preview mode enabled.")
   })
 

--- a/packages/next-drupal/tests/__mocks__/next.ts
+++ b/packages/next-drupal/tests/__mocks__/next.ts
@@ -1,6 +1,6 @@
 export const NextApiRequest = jest.fn(function () {
   this.query = {
-    slug: "/example",
+    path: "/example",
     resourceVersion: "id:1",
     plugin: "simple_oauth",
     secret: "very-secret-key",

--- a/packages/next-drupal/tests/draft/draft.test.ts
+++ b/packages/next-drupal/tests/draft/draft.test.ts
@@ -38,7 +38,7 @@ afterEach(() => {
 
 describe("enableDraftMode()", () => {
   const searchParams = new URLSearchParams({
-    slug: "/example",
+    path: "/example",
     resourceVersion: "id:1",
     plugin: "simple_oauth",
     secret: "very-secret-key",
@@ -108,12 +108,12 @@ describe("enableDraftMode()", () => {
     })
   })
 
-  test("redirects to the slug path", async () => {
+  test("redirects to the given path", async () => {
     spyOnFetch({ responseBody: validationPayload })
 
     await enableDraftMode(request, client)
 
-    expect(redirect).toHaveBeenCalledWith(searchParams.get("slug"))
+    expect(redirect).toHaveBeenCalledWith(searchParams.get("path"))
   })
 })
 
@@ -146,7 +146,7 @@ describe("disableDraftMode()", () => {
 
 describe("getDraftData()", () => {
   const draftData = {
-    slug: "/example",
+    path: "/example",
     resourceVersion: "id:1",
   }
   const draftDataCookie: ResponseCookie = {

--- a/starters/basic-starter/pages/api/revalidate.ts
+++ b/starters/basic-starter/pages/api/revalidate.ts
@@ -4,7 +4,7 @@ export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ) {
-  let slug = request.query.slug as string
+  let path = request.query.path as string
   const secret = request.query.secret as string
 
   // Validate secret.
@@ -12,13 +12,13 @@ export default async function handler(
     return response.status(401).json({ message: "Invalid secret." })
   }
 
-  // Validate slug.
-  if (!slug) {
-    return response.status(400).json({ message: "Invalid slug." })
+  // Validate path.
+  if (!path) {
+    return response.status(400).json({ message: "Invalid path." })
   }
 
   try {
-    await response.revalidate(slug)
+    await response.revalidate(path)
 
     return response.json({})
   } catch (error) {

--- a/starters/graphql-starter/pages/api/revalidate.ts
+++ b/starters/graphql-starter/pages/api/revalidate.ts
@@ -4,7 +4,7 @@ export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ) {
-  let slug = request.query.slug as string
+  let path = request.query.path as string
   const secret = request.query.secret as string
 
   // Validate secret.
@@ -12,13 +12,13 @@ export default async function handler(
     return response.status(401).json({ message: "Invalid secret." })
   }
 
-  // Validate slug.
-  if (!slug) {
-    return response.status(400).json({ message: "Invalid slug." })
+  // Validate path.
+  if (!path) {
+    return response.status(400).json({ message: "Invalid path." })
   }
 
   try {
-    await response.revalidate(slug)
+    await response.revalidate(path)
 
     return response.json({})
   } catch (error) {


### PR DESCRIPTION
This pull request is for:
- [x] `examples/*`
- [x] `modules/next`
- [x] `packages/next-drupal`
- [x] `starters/basic-starter`
- [x] `starters/graphql-starter`

GitHub Issue: #718

## Describe your changes

Replaces "slug" with "path" in revalidate/preview/draft URLs.