### PR TITLE
feat(next-drupal): translatePath, getResourceByPath - throw error when backend error

### DIFF
--- a/packages/next-drupal/tests/DrupalClient/resource-methods.test.ts
+++ b/packages/next-drupal/tests/DrupalClient/resource-methods.test.ts
@@ -449,6 +449,19 @@ describe("getResourceByPath()", () => {
     ).rejects.toThrow("Unable to resolve path /path-do-not-exist.")
   })
 
+  test("throws an error for server errors", async () => {
+    const client = new DrupalClient(BASE_URL)
+
+    spyOnFetch({
+      responseBody: { message: "mocked internal server error" },
+      status: 500,
+    })
+
+    await expect(
+      client.getResourceByPath<DrupalNode>("/server-error")
+    ).rejects.toThrow("500 mocked internal server error")
+  })
+
   test("throws an error for invalid params", async () => {
     const client = new DrupalClient(BASE_URL)
 
@@ -834,6 +847,19 @@ describe("translatePath()", () => {
     const path = await client.translatePath("/path-not-found")
 
     expect(path).toBeNull()
+  })
+
+  test("throws an error for server errors", async () => {
+    const client = new DrupalClient(BASE_URL)
+
+    spyOnFetch({
+      responseBody: { message: "mocked internal server error" },
+      status: 500,
+    })
+
+    await expect(client.translatePath("/server-error")).rejects.toThrowError(
+      "500 mocked internal server error"
+    )
   })
 
   test("makes un-authenticated requests by default", async () => {


### PR DESCRIPTION
Until now, any not-ok response from decoupled router was treated equally, as a 404 Not Found. Behaviour is changed differentiating between 404 Not Found and server error. The advantage is frontend holds to previous built page and doesn't update public page content with a 404 due to backend issues.

BREAKING CHANGE:
Might break sites relying on response being the same in 404 than in 50x.

Fixes #687

This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] Other

GitHub Issue: #
_Please add a link to the GitHub issue
where this problem is discussed._

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

A clear and concise description of what the request is.

If applicable, add screenshots to help explain your issue.
