### PR TITLE
Work-around for flakey code coverage reporting

### DIFF
--- a/.github/workflows/next-drupal.yml
+++ b/.github/workflows/next-drupal.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+      # TODO: Work-around for failing code coverage.
+      # https://github.com/chapter-three/next-drupal/issues/740
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.19.x'
       - name: Install packages
         run: yarn
       - name: Run tests

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,5 @@
-v18
+v18.19
+
+# @TODO v18.20 and v20.10 and later have a bug that causes Jest code coverage to randomly fail. When the tracking bug is fixed, switch to the less-specific "v18" or "v20" version. See https://github.com/chapter-three/next-drupal/issues/740
+
+# Note: This is a non-standard .nvmrc comment. Currently, nvm ignores all lines except the 1st line so we are hijacking this implementation detail to add comments to this file. See https://github.com/nvm-sh/nvm/pull/2288#issuecomment-1115079020


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [x] `packages/next-drupal`

GitHub Issue: #740

## Describe your changes

A change has been introduced into Node.js v18.20 and v20.10 and later that affects how Jest is able to use v8 for code coverage. Using an older version of node.js will allow the code coverage report to be reported correctly _consistently_.