### PR TITLE
Update starters/examples to beta release

### DIFF
--- a/examples/example-auth/package.json
+++ b/examples/example-auth/package.json
@@ -19,7 +19,7 @@
     "jwt-decode": "^3.1.2",
     "next": "^14.2.2",
     "next-auth": "^4.24.7",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/example-blog/package.json
+++ b/examples/example-blog/package.json
@@ -20,7 +20,7 @@
     "drupal-jsonapi-params": "^2.3.1",
     "html-react-parser": "^4.2.10",
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "nprogress": "^0.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/example-client/package.json
+++ b/examples/example-client/package.json
@@ -17,7 +17,7 @@
     "@tailwindcss/typography": "^0.5.12",
     "classnames": "^2.5.1",
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/example-custom-auth/package.json
+++ b/examples/example-custom-auth/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/example-custom-cache/package.json
+++ b/examples/example-custom-cache/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "ioredis": "^5.4.1",
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/example-custom-fetcher/package.json
+++ b/examples/example-custom-fetcher/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "cross-fetch": "^3.1.8",
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/example-custom-serializer/package.json
+++ b/examples/example-custom-serializer/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "jsonapi-serializer": "^3.6.9",
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/example-graphql/package.json
+++ b/examples/example-graphql/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@tailwindcss/typography": "^0.5.12",
     "next": "^14.2.1",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sharp": "^0.30.7"

--- a/examples/example-marketing/package.json
+++ b/examples/example-marketing/package.json
@@ -21,7 +21,7 @@
     "drupal-jsonapi-params": "^2.3.1",
     "html-react-parser": "^4.2.10",
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "nprogress": "^0.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/example-router-migration/package.json
+++ b/examples/example-router-migration/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/example-search-api/package.json
+++ b/examples/example-search-api/package.json
@@ -18,7 +18,7 @@
     "@tailwindcss/typography": "^0.5.12",
     "@tanstack/react-query": "^4.36.1",
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/example-umami/package.json
+++ b/examples/example-umami/package.json
@@ -24,7 +24,7 @@
     "jwt-decode": "^3.1.2",
     "next": "^14.2.2",
     "next-auth": "^4.24.7",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "next-i18next": "^13.3.0",
     "node-cache": "^5.1.2",
     "nprogress": "^0.2.0",

--- a/examples/example-webform/package.json
+++ b/examples/example-webform/package.json
@@ -18,7 +18,7 @@
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.12",
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.3",

--- a/starters/basic-starter/package.json
+++ b/starters/basic-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-starter",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-beta.0",
   "private": true,
   "license": "MIT",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/starters/graphql-starter/package.json
+++ b/starters/graphql-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-starter",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-beta.0",
   "private": true,
   "license": "MIT",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/starters/pages-starter/package.json
+++ b/starters/pages-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pages-starter",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-beta.0",
   "private": true,
   "license": "MIT",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "next": "^14.2.2",
-    "next-drupal": "^2.0.0-alpha.1",
+    "next-drupal": "^2.0.0-beta.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [x] `examples/*`
- [ ] `modules/next`
- [x] `packages/next-drupal`
- [x] `starters/basic-starter`
- [x] `starters/graphql-starter`
- [x] `starters/pages-starter`
- [ ] Other

## Describe your changes

This PR:
* tags all three of the starters as `2.0.0-beta.0`
* upgrades the `examples` and `starters` to use `next-drupal@^2.0.0-beta.0`
