### PR TITLE
Allow null value for `mode` parameter in getParams function 

### DIFF
--- a/examples/example-umami/lib/get-params.ts
+++ b/examples/example-umami/lib/get-params.ts
@@ -3,7 +3,7 @@ import { DrupalJsonApiParams } from "drupal-jsonapi-params"
 // A helper function to build params for a resource type.
 export function getParams(
   name: string,
-  mode: string = null
+  mode: string | null = null
 ): DrupalJsonApiParams {
   const params = new DrupalJsonApiParams()
 


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [x] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

## Description

Explicitly updated the type of the `mode` parameter to `string | null` in the `getParams` function to support cases where `mode` might be `null`. This improves flexibility and handling of optional parameters.
