### PR TITLE
Fix: Ensure all code paths return a DrupalJsonApiParams instance in getParams function

### DIFF
--- a/examples/example-umami/lib/get-params.ts
+++ b/examples/example-umami/lib/get-params.ts
@@ -135,4 +135,5 @@ export function getParams(
   if (name === "taxonomy_term--recipe_category") {
     return params.addFields("taxonomy_term--recipe_category", ["name", "path"])
   }
+  return params;
 }


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [x] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

## Desription

- Updated `getParams` function to ensure every code path returns a `DrupalJsonApiParams` instance.
- Added default return value to handle unknown `name` cases.