### PR TITLE
Add support for Drupal cache tags

### DIFF
--- a/modules/next/config/install/next.settings.yml
+++ b/modules/next/config/install/next.settings.yml
@@ -8,3 +8,4 @@ preview_url_generator: simple_oauth
 preview_url_generator_configuration:
   secret_expiration: 30
 debug: false
+queue_size: 10

--- a/modules/next/config/schema/next.schema.yml
+++ b/modules/next/config/schema/next.schema.yml
@@ -89,6 +89,9 @@ next.settings:
       type: next.preview_url_generator.configuration.[%parent.preview_url_generator]
     debug:
       type: boolean
+    queue_size:
+      type: integer
+      label: 'Queue size'
 
 next.site_previewer.configuration.iframe:
   type: mapping

--- a/modules/next/next.install
+++ b/modules/next/next.install
@@ -6,6 +6,85 @@
  */
 
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\next\CacheTagNodeMapperInterface;
+use Drupal\next\CacheTagRevalidatorTaskStoreInterface;
+
+/**
+ * Implements hook_schema().
+ */
+function next_schema() {
+  $schema = [];
+
+  $schema[CacheTagNodeMapperInterface::TABLE] = [
+    'description' => 'Cache tags mapped to associated node.',
+    'fields' => [
+      'tag' => [
+        'description' => 'Cache tag.',
+        'type' => 'varchar_ascii',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ],
+      'nid' => [
+        'description' => 'The node id using the cache tag.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'langcode' => [
+        'description' => 'The language code of the node.',
+        'type' => 'varchar_ascii',
+        'length' => 12,
+        'not null' => TRUE,
+        'default' => LanguageInterface::LANGCODE_NOT_SPECIFIED,
+      ],
+      'next_site' => [
+        'description' => 'The associated next site.',
+        'type' => 'varchar_ascii',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ],
+    ],
+    'primary key' => ['tag', 'nid', 'langcode', 'next_site'],
+    'indexes' => [
+      'tag_nid_langcode_next_site' => ['tag', 'nid', 'langcode', 'next_site'],
+    ],
+  ];
+
+  $schema[CacheTagRevalidatorTaskStoreInterface::TABLE] = [
+    'description' => 'Cache tag revalidator task storage.',
+    'fields' => [
+      'nid' => [
+        'description' => 'The node id that needs to be revalidated.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'langcode' => [
+        'description' => 'The language code of the node.',
+        'type' => 'varchar_ascii',
+        'length' => 12,
+        'not null' => TRUE,
+        'default' => LanguageInterface::LANGCODE_NOT_SPECIFIED,
+      ],
+      'next_site' => [
+        'description' => 'The associated next site.',
+        'type' => 'varchar_ascii',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ],
+    ],
+    'primary key' => ['nid', 'langcode', 'next_site'],
+    'indexes' => [
+      'nid_langcode_next_site' => ['nid', 'langcode', 'next_site'],
+    ],
+  ];
+
+  return $schema;
+}
 
 /**
  * Set simple_oauth as the preview url generator.
@@ -103,4 +182,18 @@ function next_update_9106() {
   $config = \Drupal::configFactory()->getEditable('next.settings');
   $config->set('debug', FALSE)
     ->save();
+}
+
+/**
+ * Install tables if module is already installed.
+ */
+function next_update_9107() {
+  $schema = \Drupal::database()->schema();
+  $tables = next_schema();
+  if (!$schema->tableExists(CacheTagNodeMapperInterface::TABLE)) {
+    $schema->createTable(CacheTagNodeMapperInterface::TABLE, $tables[CacheTagNodeMapperInterface::TABLE]);
+  }
+  if (!$schema->tableExists(CacheTagRevalidatorTaskStoreInterface::TABLE)) {
+    $schema->createTable(CacheTagRevalidatorTaskStoreInterface::TABLE, $tables[CacheTagRevalidatorTaskStoreInterface::TABLE]);
+  }
 }

--- a/modules/next/next.services.yml
+++ b/modules/next/next.services.yml
@@ -81,10 +81,10 @@ services:
       - { name: event_subscriber }
   next.cache_tag_node_mapper:
     class: Drupal\next\CacheTagNodeMapper
-    arguments: [ '@database' ]
+    arguments: ['@database']
   next.cache_tag_revalidator_task_store:
     class: Drupal\next\CacheTagRevalidatorTaskStore
-    arguments: [ '@database' ]
+    arguments: ['@database']
   next.path_revalidator_helper:
     class: Drupal\next\PathRevalidatorHelper
     arguments:

--- a/modules/next/next.services.yml
+++ b/modules/next/next.services.yml
@@ -71,3 +71,24 @@ services:
     arguments: ['@event_dispatcher']
     tags:
       - { name: needs_destruction }
+  next.resource_response.subscriber:
+    class: Drupal\next\EventSubscriber\ResourceResponseSubscriber
+    arguments:
+      - '@entity_type.manager'
+      - '@language_manager'
+      - '@next.cache_tag_node_mapper'
+    tags:
+      - { name: event_subscriber }
+  next.cache_tag_node_mapper:
+    class: Drupal\next\CacheTagNodeMapper
+    arguments: [ '@database' ]
+  next.cache_tag_revalidator_task_store:
+    class: Drupal\next\CacheTagRevalidatorTaskStore
+    arguments: [ '@database' ]
+  next.path_revalidor_helper:
+    class: Drupal\next\PathRevalidatorHelper
+    arguments:
+      - '@entity_type.manager'
+      - '@next.settings.manager'
+      - '@http_client'
+      - '@logger.channel.next'

--- a/modules/next/next.services.yml
+++ b/modules/next/next.services.yml
@@ -85,7 +85,7 @@ services:
   next.cache_tag_revalidator_task_store:
     class: Drupal\next\CacheTagRevalidatorTaskStore
     arguments: [ '@database' ]
-  next.path_revalidor_helper:
+  next.path_revalidator_helper:
     class: Drupal\next\PathRevalidatorHelper
     arguments:
       - '@entity_type.manager'

--- a/modules/next/src/CacheTagNodeMapper.php
+++ b/modules/next/src/CacheTagNodeMapper.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\next;
+
+use Drupal\Core\Database\Connection;
+
+/**
+ * Defines the cache tag node mapper service.
+ */
+class CacheTagNodeMapper implements CacheTagNodeMapperInterface {
+
+  /**
+   * Database Service Object.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  private Connection $connection;
+
+  /**
+   * Construct the CacheTagNodeMapper.
+   *
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection.
+   */
+  public function __construct(Connection $connection) {
+    $this->connection = $connection;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTagsByNid(int $nid, string $langcode, string $next_site): array {
+    return $this->connection->select(self::TABLE, 'c')
+      ->fields('c', ['tag'])
+      ->condition('c.nid', $nid)
+      ->condition('c.langcode', $langcode)
+      ->condition('c.next_site', $next_site)
+      ->execute()
+      ->fetchCol();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getNidsByCacheTag(string $cache_tag, string $langcode, $next_site): array {
+    return $this->connection->select(self::TABLE, 'c')
+      ->fields('c', ['nid'])
+      ->condition('c.tag', $cache_tag)
+      ->condition('c.langcode', $langcode)
+      ->condition('c.next_site', $next_site)
+      ->distinct()
+      ->execute()
+      ->fetchCol();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete(array $cache_tags, string $langcode, ?int $nid = NULL, ?string $next_site = NULL): void {
+    $query = $this->connection->delete(self::TABLE)
+      ->condition('langcode', $langcode);
+
+    if (count($cache_tags) > 1) {
+      $query->condition('tag', $cache_tags, 'IN');
+    }
+    else {
+      $query->condition('tag', reset($cache_tags));
+    }
+
+    if ($nid) {
+      $query->condition('nid', $nid);
+    }
+    if ($next_site) {
+      $query->condition('next_site', $next_site);
+    }
+
+    $query->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function add(array $values): void {
+    $query = $this->connection->insert(self::TABLE)
+      ->fields(['tag', 'nid', 'langcode', 'next_site']);
+    foreach ($values as $row) {
+      $query->values($row);
+    }
+    $query->execute();
+  }
+
+}

--- a/modules/next/src/CacheTagNodeMapperInterface.php
+++ b/modules/next/src/CacheTagNodeMapperInterface.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\next;
+
+/**
+ * Cache tag node mapper interface.
+ */
+interface CacheTagNodeMapperInterface {
+
+  /**
+   * The table name.
+   */
+  const TABLE = 'cachetag_node_map';
+
+  /**
+   * Get cache tags by node id.
+   *
+   * @param int $nid
+   *   The node id.
+   * @param string $langcode
+   *   The language code.
+   * @param string $next_site
+   *   The next site id.
+   *
+   * @return array
+   *   Returns array with cache tags.
+   */
+  public function getCacheTagsByNid(int $nid, string $langcode, string $next_site): array;
+
+  /**
+   * Get node id's by cache tag.
+   *
+   * @param string $cache_tag
+   *   The cache tag.
+   * @param string $langcode
+   *   The language code.
+   * @param string $next_site
+   *   The next site id.
+   *
+   * @return array
+   *   Returns array with node id's.
+   */
+  public function getNidsByCacheTag(string $cache_tag, string $langcode, string $next_site): array;
+
+  /**
+   * Delete cache tags.
+   *
+   * @param array $cache_tags
+   *   The cache tags.
+   * @param string $langcode
+   *   The language code.
+   * @param int|null $nid
+   *   Optional node id.
+   * @param string|null $next_site
+   *   Optional next site id.
+   */
+  public function delete(array $cache_tags, string $langcode, ?int $nid = NULL, ?string $next_site = NULL): void;
+
+  /**
+   * Add cache tags.
+   *
+   * @param array $values
+   *   Cache tags values to add.
+   *   E.g: [
+   *     [
+   *       'tag' => 'node:1',
+   *       'nid' => '1',
+   *       'langcode' => 'en',
+   *       'next_site' => example,
+   *     ]
+   *   ].
+   */
+  public function add(array $values): void;
+
+}

--- a/modules/next/src/CacheTagRevalidatorTaskStore.php
+++ b/modules/next/src/CacheTagRevalidatorTaskStore.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\next;
+
+use Drupal\Core\Database\Connection;
+
+/**
+ * Defines the cache tag revalidator task store service.
+ */
+class CacheTagRevalidatorTaskStore implements CacheTagRevalidatorTaskStoreInterface {
+
+  /**
+   * Database Service Object.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  private Connection $connection;
+
+  /**
+   * Construct the CacheTagRevalidatorTaskStore.
+   *
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection.
+   */
+  public function __construct(Connection $connection) {
+    $this->connection = $connection;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function set(array $nids, string $langcode, string $next_site): void {
+    $query = $this->connection->insert(self::TABLE)
+      ->fields(['nid', 'langcode', 'next_site']);
+    foreach ($nids as $nid) {
+      $query->values([
+        'nid' => $nid,
+        'langcode' => $langcode,
+        'next_site' => $next_site,
+      ]);
+    }
+    $query->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function has(int $nid, string $langcode, string $next_site): bool {
+    return (bool) $this->connection->select(self::TABLE, 'c')
+      ->fields('c', ['nid'])
+      ->condition('c.nid', $nid)
+      ->condition('c.langcode', $langcode)
+      ->condition('c.next_site', $next_site)
+      ->execute()
+      ->fetchField();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete(array $nids, string $langcode, string $next_site): void {
+    $this->connection->delete(self::TABLE)
+      ->condition('nid', $nids, 'IN')
+      ->condition('langcode', $langcode)
+      ->condition('next_site', $next_site)
+      ->execute();
+  }
+
+}

--- a/modules/next/src/CacheTagRevalidatorTaskStoreInterface.php
+++ b/modules/next/src/CacheTagRevalidatorTaskStoreInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\next;
+
+/**
+ * Cache tag node mapper interface.
+ */
+interface CacheTagRevalidatorTaskStoreInterface {
+
+  /**
+   * The table name.
+   */
+  const TABLE = 'cachetag_revalidator_task_store';
+
+  /**
+   * Saves a cache tag revalidator task item.
+   *
+   * @param array $nids
+   *   The node id's.
+   * @param string $langcode
+   *   The langcode.
+   * @param string $next_site
+   *   The next site id.
+   */
+  public function set(array $nids, string $langcode, string $next_site): void;
+
+  /**
+   * Checks if a cache tag revalidator task item exist.
+   *
+   * @param int $nid
+   *   The node id.
+   * @param string $langcode
+   *   The langcode.
+   * @param string $next_site
+   *   The next site id.
+   *
+   * @return bool
+   *   Return true or false.
+   */
+  public function has(int $nid, string $langcode, string $next_site): bool;
+
+  /**
+   * Delete cache tag revalidator task items.
+   *
+   * @param array $nids
+   *   The node id's.
+   * @param string $langcode
+   *   The langcode.
+   * @param string $next_site
+   *   The next site id.
+   */
+  public function delete(array $nids, string $langcode, string $next_site): void;
+
+}

--- a/modules/next/src/EventSubscriber/ResourceResponseSubscriber.php
+++ b/modules/next/src/EventSubscriber/ResourceResponseSubscriber.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Drupal\next\EventSubscriber;
+
+use Drupal\Core\Cache\CacheableResponseInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\next\CacheTagNodeMapperInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Response subscriber that registers cache tags.
+ *
+ * @see \Drupal\rest\EventSubscriber\ResourceResponseSubscriber
+ */
+class ResourceResponseSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  private LanguageManagerInterface $languageManager;
+
+  /**
+   * The cache tag node mapper service.
+   *
+   * @var \Drupal\next\CacheTagNodeMapperInterface
+   */
+  private CacheTagNodeMapperInterface $cacheTagNodeMapper;
+
+  /**
+   * Constructs a ResourceResponseSubscriber object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   * @param \Drupal\next\CacheTagNodeMapperInterface $cache_tag_node_mapper
+   *   The cache tag node mapper service.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    LanguageManagerInterface $language_manager,
+    CacheTagNodeMapperInterface $cache_tag_node_mapper
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->languageManager = $language_manager;
+    $this->cacheTagNodeMapper = $cache_tag_node_mapper;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @see \Drupal\rest\EventSubscriber\ResourceResponseSubscriber::getSubscribedEvents()
+   * @see \Drupal\dynamic_page_cache\EventSubscriber\DynamicPageCacheSubscriber
+   */
+  public static function getSubscribedEvents(): array {
+    // Run before the dynamic page cache subscriber (priority 100), so that
+    // Dynamic Page Cache can cache flattened responses.
+    $events[KernelEvents::RESPONSE][] = ['onResponse', 100];
+    return $events;
+  }
+
+  /**
+   * Retrieve cache tags from response and register them.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The event to process.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function onResponse(ResponseEvent $event): void {
+    $response = $event->getResponse();
+    $request = $event->getRequest();
+    $entity = $request->attributes->get('entity');
+    $next_site = $request->headers->get('X-NextJS-Site');
+
+    if (
+      $request->getRequestFormat() !== 'api_json' ||
+      $request->attributes->get('_controller') !== 'jsonapi.entity_resource:getIndividual' ||
+      !$response instanceof CacheableResponseInterface ||
+      !$entity instanceof NodeInterface ||
+      empty($next_site) ||
+      !$this->entityTypeManager->getStorage('next_site')->load($next_site)
+    ) {
+      return;
+    }
+
+    $langcode = $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_URL)->getId();
+
+    // Filter cache tags from response with only enabled next entity types.
+    $cache_tags = $this->filterCacheTagsByNextEntityTypes($response->getCacheableMetadata()->getCacheTags());
+
+    // Get existing stored cache tags for the associated node.
+    $existing_cache_tags = $this->cacheTagNodeMapper->getCacheTagsByNid($entity->id(), $langcode, $next_site);
+
+    // Remove stored cache tags that are no longer active on the response.
+    $delete_cache_tags = [];
+    foreach ($existing_cache_tags as $cache_tag => $nid) {
+      if (!in_array($cache_tag, $cache_tags)) {
+        $delete_cache_tags[] = $cache_tag;
+      }
+    }
+    if (!empty($delete_cache_tags)) {
+      $this->cacheTagNodeMapper->delete($delete_cache_tags, $langcode, $entity->id(), $next_site);
+    }
+
+    // Add new cache tags.
+    $rows = [];
+    foreach ($cache_tags as $cache_tag) {
+      if (!in_array($cache_tag, $existing_cache_tags)) {
+        $rows[] = [
+          'tag' => $cache_tag,
+          'nid' => $entity->id(),
+          'langcode' => $langcode,
+          'next_site' => $next_site,
+        ];
+      }
+    }
+    if (!empty($rows)) {
+      $this->cacheTagNodeMapper->add($rows);
+    }
+  }
+
+  /**
+   * Filter the cache tags by active next entity types.
+   *
+   * @param array $cache_tags
+   *   The cache tags to filter.
+   *
+   * @return array
+   *   Returns array with filtered cache tags.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  private function filterCacheTagsByNextEntityTypes(array $cache_tags): array {
+    $storage = $this->entityTypeManager->getStorage('next_entity_type_config');
+    /** @var \Drupal\next\Entity\NextEntityTypeConfigInterface[] $next_entity_types */
+    $next_entity_types = $storage->loadByProperties([
+      'status' => TRUE,
+      'revalidator' => 'cache_tag',
+    ]);
+
+    // Collect enabled next entity types, mapped with bundles.
+    $entity_type_id_bundle_map = [];
+    foreach ($next_entity_types as $next_entity_type) {
+      $id = explode('.', $next_entity_type->id());
+      $entity_type_id_bundle_map[$id[0]][] = $id[1];
+    }
+    $entity_type_id_bundles_str = [];
+    foreach ($entity_type_id_bundle_map as $entity_type_id => $bundles) {
+      $entity_type_id_bundles_str[$entity_type_id] = implode('|', $bundles);
+    }
+
+    $filtered_cache_tags = [];
+    foreach ($cache_tags as $cache_tag) {
+      // Extract the first part of the cache tag, which is the entity type id.
+      $cache_tag_parts = explode(':', $cache_tag);
+      $entity_type_id = $cache_tag_parts[0];
+      // Support entity list cache tags.
+      if (strpos($entity_type_id, '_list')) {
+        $entity_type_id = str_replace('_list', '', $entity_type_id);
+      }
+      // Check if entity type is enabled in next.
+      if (array_key_exists($entity_type_id, $entity_type_id_bundles_str)) {
+        $bundles_str = $entity_type_id_bundles_str[$entity_type_id];
+        // Check for associated entity cache tags, including list cache tags.
+        if (preg_match("/^$entity_type_id(?:_list|_list:(?:$bundles_str)|:[0-9]+)$/", $cache_tag)) {
+          $filtered_cache_tags[] = $cache_tag;
+        }
+      }
+    }
+
+    return $filtered_cache_tags;
+  }
+
+}

--- a/modules/next/src/Form/NextSettingsForm.php
+++ b/modules/next/src/Form/NextSettingsForm.php
@@ -177,6 +177,19 @@ class NextSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('debug'),
     ];
 
+    $form['revalidate'] = [
+      '#title' => $this->t('Revalidate'),
+      '#type' => 'details',
+      '#group' => 'settings',
+      'queue_size' => [
+        '#title' => $this->t('Queue size'),
+        '#description' => $this->t('Amount of nodes to be revalidated in a single queue.'),
+        '#type' => 'number',
+        '#default_value' => $config->get('queue_size'),
+        '#min' => 0,
+      ],
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -259,6 +272,7 @@ class NextSettingsForm extends ConfigFormBase {
       ->set('preview_url_generator', $form_state->getValue('preview_url_generator'))
       ->set('preview_url_generator_configuration', $form_state->getValue('preview_url_generator_configuration'))
       ->set('debug', $form_state->getValue('debug'))
+      ->set('queue_size', $form_state->getValue('queue_size'))
       ->save();
   }
 

--- a/modules/next/src/PathRevalidatorHelper.php
+++ b/modules/next/src/PathRevalidatorHelper.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\next;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Utility\Error;
+use Drupal\next\Entity\NextSiteInterface;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Defines the path revalidator helper service.
+ */
+class PathRevalidatorHelper implements PathRevalidatorHelperInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The next settings manager.
+   *
+   * @var \Drupal\next\NextSettingsManagerInterface
+   */
+  private NextSettingsManagerInterface $nextSettingsManager;
+
+  /**
+   * The http client.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  private ClientInterface $httpClient;
+
+  /**
+   * The logger.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  private LoggerChannelInterface $logger;
+
+  /**
+   * Construct the PathRevalidatorHelper.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\next\NextSettingsManagerInterface $next_settings_manager
+   *   The next settings manager.
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   The http client.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   The logger.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    NextSettingsManagerInterface $next_settings_manager,
+    ClientInterface $http_client,
+    LoggerChannelInterface $logger
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->nextSettingsManager = $next_settings_manager;
+    $this->httpClient = $http_client;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function revalidatePathByNodeIds(
+    array $nids,
+    string $langcode,
+    NextSiteInterface $site,
+    string $event_action
+  ): void {
+    /** @var \Drupal\node\NodeInterface[] $nodes */
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+    foreach ($nodes as $node) {
+      $translation = $node->getTranslation($langcode);
+      $path = $translation->toUrl()->toString();
+      $this->revalidatePath($path, $site, $event_action);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function revalidatePath(
+    string $path,
+    NextSiteInterface $site,
+    string $event_action
+  ): void {
+    try {
+      $revalidate_url = $site->getRevalidateUrlForPath($path);
+
+      if (!$revalidate_url) {
+        throw new \Exception('No revalidate url set.');
+      }
+
+      if ($this->nextSettingsManager->isDebug()) {
+        $this->logger->notice('(@action): Revalidating path %path for the site %site. URL: %url', [
+          '@action' => $event_action,
+          '%path' => $path,
+          '%site' => $site->label(),
+          '%url' => $revalidate_url->toString(),
+        ]);
+      }
+
+      $response = $this->httpClient->request('GET', $revalidate_url->toString());
+      if ($response && $response->getStatusCode() === Response::HTTP_OK) {
+        if ($this->nextSettingsManager->isDebug()) {
+          $this->logger->notice('(@action): Successfully revalidated path %path for the site %site. URL: %url', [
+            '@action' => $event_action,
+            '%path' => $path,
+            '%site' => $site->label(),
+            '%url' => $revalidate_url->toString(),
+          ]);
+        }
+      }
+    }
+    catch (\Exception $exception) {
+      Error::logException($this->logger, $exception);
+    }
+  }
+
+}

--- a/modules/next/src/PathRevalidatorHelperInterface.php
+++ b/modules/next/src/PathRevalidatorHelperInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\next;
+
+use Drupal\next\Entity\NextSiteInterface;
+
+/**
+ * Path revalidator helper interface.
+ */
+interface PathRevalidatorHelperInterface {
+
+  /**
+   * Revalidate paths by node ids.
+   *
+   * @param array $nids
+   *   The node id's to revalidate.
+   * @param string $langcode
+   *   The associated langcode.
+   * @param \Drupal\next\Entity\NextSiteInterface $site
+   *   The next site to revalidate the nodes on.
+   * @param string $event_action
+   *   The event action.
+   */
+  public function revalidatePathByNodeIds(
+    array $nids,
+    string $langcode,
+    NextSiteInterface $site,
+    string $event_action
+  ): void;
+
+  /**
+   * Revalidate path.
+   *
+   * @param string $path
+   *   The path of the node to revalidate.
+   * @param \Drupal\next\Entity\NextSiteInterface $site
+   *   The associated next site.
+   * @param string $event_action
+   *   The event action.
+   */
+  public function revalidatePath(
+    string $path,
+    NextSiteInterface $site,
+    string $event_action
+  ): void;
+
+}

--- a/modules/next/src/Plugin/Next/Revalidator/CacheTag.php
+++ b/modules/next/src/Plugin/Next/Revalidator/CacheTag.php
@@ -124,7 +124,7 @@ class CacheTag extends ConfigurableRevalidatorBase implements RevalidatorInterfa
       $container->get('logger.channel.next'),
       $container->get('config.factory')->get('next.settings'),
       $container->get('next.cache_tag_node_mapper'),
-      $container->get('next.path_revalidor_helper'),
+      $container->get('next.path_revalidator_helper'),
       $container->get('queue')->get('cache_tag_revalidator', TRUE),
       $container->get('next.cache_tag_revalidator_task_store')
     );

--- a/modules/next/src/Plugin/Next/Revalidator/CacheTag.php
+++ b/modules/next/src/Plugin/Next/Revalidator/CacheTag.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Drupal\next\Plugin\Next\Revalidator;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Queue\QueueInterface;
+use Drupal\next\Event\EntityActionEvent;
+use Drupal\next\NextSettingsManagerInterface;
+use Drupal\next\Plugin\ConfigurableRevalidatorBase;
+use Drupal\next\Plugin\RevalidatorInterface;
+use Drupal\node\NodeInterface;
+use Drupal\next\CacheTagNodeMapperInterface;
+use Drupal\next\CacheTagRevalidatorTaskStoreInterface;
+use Drupal\next\PathRevalidatorHelperInterface;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a revalidator for cache tags.
+ *
+ * @Revalidator(
+ *  id = "cache_tag",
+ *  label = "Cache tag",
+ *  description = "Cache tag on-demand revalidation."
+ * )
+ */
+class CacheTag extends ConfigurableRevalidatorBase implements RevalidatorInterface {
+
+  /**
+   * The next settings config.
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  private Config $settingsConfig;
+
+  /**
+   * The cache tag node mapper service.
+   *
+   * @var \Drupal\next\CacheTagNodeMapperInterface
+   */
+  private CacheTagNodeMapperInterface $cacheTagNodeMapper;
+
+  /**
+   * The path revalidator helper service.
+   *
+   * @var \Drupal\next\PathRevalidatorHelperInterface
+   */
+  private PathRevalidatorHelperInterface $pathRevalidatorHelper;
+
+  /**
+   * The queue object.
+   *
+   * @var \Drupal\Core\Queue\QueueInterface
+   */
+  private QueueInterface $queue;
+
+  /**
+   * The cache tag revalidator task store service.
+   *
+   * @var \Drupal\next\CacheTagRevalidatorTaskStoreInterface
+   */
+  private CacheTagRevalidatorTaskStoreInterface $taskStore;
+
+  /**
+   * CacheTag constructor.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\next\NextSettingsManagerInterface $next_settings_manager
+   *   The next settings manager.
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   The http client.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   The logger.
+   * @param \Drupal\Core\Config\Config $settings_config
+   *   The next settings config.
+   * @param \Drupal\next\CacheTagNodeMapperInterface $cache_tag_node_mapper
+   *   The cache tag node mapper service.
+   * @param \Drupal\next\PathRevalidatorHelperInterface $path_revalidator_helper
+   *   The path revalidator helper service.
+   * @param \Drupal\Core\Queue\QueueInterface $queue
+   *   The queue object.
+   * @param \Drupal\next\CacheTagRevalidatorTaskStoreInterface $task_store
+   *   The cache tag revalidator task store service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    NextSettingsManagerInterface $next_settings_manager,
+    ClientInterface $http_client,
+    LoggerChannelInterface $logger,
+    Config $settings_config,
+    CacheTagNodeMapperInterface $cache_tag_node_mapper,
+    PathRevalidatorHelperInterface $path_revalidator_helper,
+    QueueInterface $queue,
+    CacheTagRevalidatorTaskStoreInterface $task_store
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $next_settings_manager, $http_client, $logger);
+    $this->settingsConfig = $settings_config;
+    $this->cacheTagNodeMapper = $cache_tag_node_mapper;
+    $this->pathRevalidatorHelper = $path_revalidator_helper;
+    $this->queue = $queue;
+    $this->taskStore = $task_store;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('next.settings.manager'),
+      $container->get('http_client'),
+      $container->get('logger.channel.next'),
+      $container->get('config.factory')->get('next.settings'),
+      $container->get('next.cache_tag_node_mapper'),
+      $container->get('next.path_revalidor_helper'),
+      $container->get('queue')->get('cache_tag_revalidator', TRUE),
+      $container->get('next.cache_tag_revalidator_task_store')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function revalidate(EntityActionEvent $event): bool {
+    $sites = $event->getSites();
+    if (!count($sites)) {
+      return FALSE;
+    }
+
+    $entity = $event->getEntity();
+    $event_action = $event->getAction();
+    $langcode = $entity->language()->getId();
+    $queue_size = $this->settingsConfig->get('queue_size');
+
+    foreach ($sites as $site) {
+      $nids = [];
+      foreach ($this->getCacheTagsToInvalidate($entity) as $cache_tag) {
+        $nids = array_merge($nids, $this->cacheTagNodeMapper->getNidsByCacheTag($cache_tag, $langcode, $site->id()));
+      }
+
+      // If the event is triggered on a node, we revalidate the associated
+      // node directly and remove it from the task store.
+      if ($entity instanceof NodeInterface) {
+        // Filter out the current node.
+        $nids = array_filter($nids, function ($nid) use ($entity) {
+          return $nid !== $entity->id();
+        });
+
+        $this->pathRevalidatorHelper->revalidatePath($event->getEntityUrl(), $site, $event_action);
+        if ($this->taskStore->has($entity->id(), $langcode, $site->id())) {
+          $this->taskStore->delete([$entity->id()], $langcode, $site->id());
+        }
+      }
+
+      // If queue size is not available, we revalidate all associated nodes
+      // directly.
+      if (!$queue_size) {
+        $this->pathRevalidatorHelper->revalidatePathByNodeIds($nids, $langcode, $site, $event_action);
+        continue;
+      }
+
+      // Filter out the node id's that are already queued.
+      $nids = array_filter($nids, function ($nid) use ($langcode, $site) {
+        return !$this->taskStore->has($nid, $langcode, $site->id());
+      });
+
+      foreach (array_chunk($nids, $queue_size) as $order => $nids_chunk) {
+        // If the queue is empty and we are dealing with the first array chunk,
+        // the items get directly revalidated.
+        if (!$this->queue->numberOfItems() && !$order) {
+          $this->pathRevalidatorHelper->revalidatePathByNodeIds($nids_chunk, $langcode, $site, $event_action);
+          continue;
+        }
+
+        $data = [
+          'nids' => $nids_chunk,
+          'langcode' => $langcode,
+          'site' => $site,
+          'event_action' => $event_action,
+        ];
+        $this->queue->createItem($data);
+        $this->taskStore->set($nids_chunk, $langcode, $site->id());
+      }
+    }
+
+    // On delete action remove associated cache tags.
+    if ($event->getAction() === 'delete') {
+      $this->cacheTagNodeMapper->delete($entity->getCacheTags(), $langcode);
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * The cache tags to invalidate for this entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to retrieve cache tags from.
+   *
+   * @return string[]
+   *   Set of list cache tags.
+   */
+  private function getCacheTagsToInvalidate(EntityInterface $entity) {
+    $tags = $entity->getEntityType()->getListCacheTags();
+    if ($entity->getEntityType()->hasKey('bundle')) {
+      $tags[] = $entity->getEntityTypeId() . '_list:' . $entity->bundle();
+    }
+    return array_merge($entity->getCacheTags(), $tags);
+  }
+
+}

--- a/modules/next/src/Plugin/QueueWorker/CacheTagRevalidator.php
+++ b/modules/next/src/Plugin/QueueWorker/CacheTagRevalidator.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\next\Plugin\QueueWorker;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\next\CacheTagRevalidatorTaskStoreInterface;
+use Drupal\next\PathRevalidatorHelperInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Process a queue of nodes to revalidate.
+ *
+ * @QueueWorker(
+ *   id = "cache_tag_revalidator",
+ *   title = @Translation("Cache tag revalidator"),
+ *   cron = {"time" = 60}
+ * )
+ */
+class CacheTagRevalidator extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The path revalidator helper service.
+   *
+   * @var \Drupal\next\PathRevalidatorHelperInterface
+   */
+  private PathRevalidatorHelperInterface $pathRevalidatorHelper;
+
+  /**
+   * The cache tag revalidator task store service.
+   *
+   * @var \Drupal\next\CacheTagRevalidatorTaskStoreInterface
+   */
+  private CacheTagRevalidatorTaskStoreInterface $taskStore;
+
+  /**
+   * Constructs a new class instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\next\PathRevalidatorHelperInterface $path_revalidator_helper
+   *   The path revalidator helper service.
+   * @param \Drupal\next\CacheTagRevalidatorTaskStoreInterface $task_store
+   *   The cache tag revalidator task store service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    PathRevalidatorHelperInterface $path_revalidator_helper,
+    CacheTagRevalidatorTaskStoreInterface $task_store
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->pathRevalidatorHelper = $path_revalidator_helper;
+    $this->taskStore = $task_store;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('next.path_revalidor_helper'),
+      $container->get('next.cache_tag_revalidator_task_store')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    $this->pathRevalidatorHelper->revalidatePathByNodeIds(
+      $data['nids'],
+      $data['langcode'],
+      $data['site'],
+      $data['event_action']
+    );
+    $this->taskStore->delete(
+      $data['nids'],
+      $data['langcode'],
+      $data['site']->id()
+    );
+  }
+
+}

--- a/modules/next/tests/src/Functional/ResourceResponseSubscriberTest.php
+++ b/modules/next/tests/src/Functional/ResourceResponseSubscriberTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Drupal\Tests\next\Functional;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\language\Entity\ContentLanguageSettings;
+use Drupal\next\Entity\NextEntityTypeConfig;
+use Drupal\next\Entity\NextSite;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
+use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+
+/**
+ * Tests the cache tag resource response subscriber.
+ *
+ * @coversDefaultClass \Drupal\next\EventSubscriber\ResourceResponseSubscriber
+ *
+ * @group next
+ */
+class ResourceResponseSubscriberTest extends BrowserTestBase {
+
+  use EntityReferenceFieldCreationTrait;
+
+  /**
+   * Test node with translation.
+   *
+   * @var \Drupal\node\Entity\Node
+   */
+  protected $nodeWithTranslation;
+
+  /**
+   * The cache tag node mapper service.
+   *
+   * @var \Drupal\next\CacheTagNodeMapperInterface
+   */
+  protected $cacheTagNodeMapper;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'content_translation',
+    'jsonapi',
+    'language',
+    'next',
+    'node',
+    'path',
+    'next',
+    'serialization',
+    'taxonomy',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->cacheTagNodeMapper = $this->container->get('next.cache_tag_node_mapper');
+
+    ConfigurableLanguage::createFromLangcode('nl')->save();
+    \Drupal::configFactory()->getEditable('language.negotiation')
+      ->set('url.prefixes.en', 'en')
+      ->set('url.prefixes.nl', 'nl')
+      ->save();
+
+    NodeType::create([
+      'type' => 'article',
+    ])->save();
+
+    ContentLanguageSettings::create([
+      'target_entity_type_id' => 'node',
+      'target_bundle' => 'article',
+    ])
+      ->setThirdPartySetting('content_translation', 'enabled', TRUE)
+      ->save();
+
+    Vocabulary::create([
+      'vid' => 'tags',
+      'name' => 'Tags',
+    ])->save();
+    $this->createEntityReferenceField(
+      'node',
+      'article',
+      'field_tags',
+      'Tags',
+      'taxonomy_term',
+      'default',
+      [
+        'target_bundles' => [
+          'tags' => 'tags',
+        ],
+        'auto_create' => TRUE,
+      ],
+      FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED
+    );
+
+    NextSite::create([
+      'id' => 'test',
+      'revalidate_url' => 'http://test.com/api/revalidate',
+      'revalidate_secret' => '12345',
+    ])->save();
+
+    foreach (['node' => 'article', 'taxonomy_term' => 'tags'] as $entity_type => $bundle) {
+      NextEntityTypeConfig::create([
+        'id' => "{$entity_type}.{$bundle}",
+        'preview_enabled' => FALSE,
+        'site_resolver' => 'site_selector',
+        'configuration' => [
+          'sites' => [
+            'test' => 'test',
+          ],
+        ],
+        'revalidator' => 'cache_tag',
+      ])->save();
+    }
+
+    $this->drupalLogin($this->drupalCreateUser(['access content']));
+    \Drupal::service('router.builder')->rebuild();
+  }
+
+  /**
+   * Test jsonapi requests.
+   */
+  public function testJsonApiRequest() {
+    $node = Node::create([
+      'type' => 'article',
+      'title' => $this->randomString(),
+    ]);
+    $node->save();
+
+    // Not a jsonapi individual request.
+    $this->drupalGet($node->toUrl()->toString());
+    $this->assertEmpty($this->cacheTagNodeMapper->getCacheTagsByNid($node->id(), 'en', 'test'));
+
+    // A jsonapi individual request with missing X-NextJS-Site header.
+    $this->getIndividual($node);
+    $this->assertEmpty($this->cacheTagNodeMapper->getCacheTagsByNid($node->id(), 'en', 'test'));
+
+    // A jsonapi individual request with incorrect X-NextJS-Site header value.
+    $this->getIndividual($node, [], ['X-NextJS-Site' => 'undefined']);
+    $this->assertEmpty($this->cacheTagNodeMapper->getCacheTagsByNid($node->id(), 'en', 'test'));
+
+    $this->getIndividual($node, [], ['X-NextJS-Site' => 'test']);
+    $this->assertEquals(
+      $node->getCacheTags(),
+      $this->cacheTagNodeMapper->getCacheTagsByNid($node->id(), 'en', 'test')
+    );
+  }
+
+  /**
+   * Test multilingual jsonapi requests.
+   */
+  public function testMultilingualJsonApiRequest() {
+    $node = Node::create([
+      'type' => 'article',
+      'title' => $this->randomString(),
+    ]);
+    $node->addTranslation('nl', ['title' => $this->randomString()]);
+    $node->save();
+
+    $this->jsonapiGet("/nl/jsonapi/node/article/{$node->uuid()}", [], ['X-NextJS-Site' => 'test']);
+    $this->assertEquals(
+      $node->getCacheTags(),
+      $this->cacheTagNodeMapper->getCacheTagsByNid($node->id(), 'nl', 'test')
+    );
+  }
+
+  /**
+   * Test jsonapi requests with include.
+   */
+  public function testJsonApiRequestWithInclude() {
+    $term = Term::create([
+      'vid' => 'tags',
+      'name' => $this->randomString(),
+    ]);
+    $term->save();
+    $node = Node::create([
+      'type' => 'article',
+      'title' => $this->randomString(),
+      'field_tags' => $term->id(),
+    ]);
+    $node->save();
+
+    $this->getIndividual(
+      $node,
+      ['query' => ['include' => 'field_tags']],
+      ['X-NextJS-Site' => 'test']
+    );
+    $this->assertEquals(
+      array_merge($node->getCacheTags(), $term->getCacheTags()),
+      $this->cacheTagNodeMapper->getCacheTagsByNid($node->id(), 'en', 'test')
+    );
+  }
+
+  /**
+   * Performs JSON:API request for the given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to request.
+   * @param array $options
+   *   URL options.
+   * @param array $headers
+   *   Request headers.
+   */
+  protected function getIndividual(EntityInterface $entity, array $options = [], array $headers = []): void {
+    $entity_type_id = $entity->getEntityTypeId();
+    $bundle = $entity->bundle();
+    $path = "/jsonapi/{$entity_type_id}/{$bundle}/{$entity->uuid()}";
+    $this->jsonapiGet($path, $options, $headers);
+  }
+
+  /**
+   * Performs JSON:API request.
+   *
+   * @param string $path
+   *   The request path.
+   * @param array $options
+   *   URL options.
+   * @param array $headers
+   *   Request headers.
+   */
+  protected function jsonapiGet(string $path, array $options = [], array $headers = []): void {
+    $this->drupalGet($path, $options, [
+      'Accept' => 'application/vnd.api+json',
+    ] + $headers);
+  }
+
+}

--- a/modules/next/tests/src/Kernel/CacheTagNodeMapperTest.php
+++ b/modules/next/tests/src/Kernel/CacheTagNodeMapperTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Drupal\Tests\next\Kernel\Plugin;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\next\CacheTagNodeMapperInterface;
+
+/**
+ * Tests the cache tag node mapper service.
+ *
+ * @coversDefaultClass \Drupal\next\CacheTagNodeMapper
+ *
+ * @group next
+ */
+class CacheTagNodeMapperTest extends KernelTestBase {
+
+  /**
+   * The cache tag node mapper service.
+   *
+   * @var \Drupal\next\CacheTagNodeMapperInterface
+   */
+  protected $cacheTagNodeMapper;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'next',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installSchema('next', [
+      CacheTagNodeMapperInterface::TABLE,
+    ]);
+
+    $this->cacheTagNodeMapper = $this->container->get('next.cache_tag_node_mapper');
+
+    $this->cacheTagNodeMapper->add([
+      ['node:1', 1, 'en', 'test'],
+      ['node:2', 1, 'nl', 'test'],
+      ['node:3', 1, 'en', 'test1'],
+      ['node:4', 2, 'en', 'test'],
+      ['taxonomy_term:1', 1, 'en', 'test'],
+      ['taxonomy_term:2', 1, 'nl', 'test'],
+      ['taxonomy_term:3', 1, 'en', 'test1'],
+      ['taxonomy_term:4', 2, 'en', 'test'],
+    ]);
+  }
+
+  /**
+   * @covers ::getCacheTagsByNid
+   */
+  public function testGetCacheTagsByNid() {
+    $this->assertEquals(
+      ['node:1', 'taxonomy_term:1'],
+      $this->cacheTagNodeMapper->getCacheTagsByNid(1, 'en', 'test')
+    );
+    $this->assertEquals(
+      ['node:4', 'taxonomy_term:4'],
+      $this->cacheTagNodeMapper->getCacheTagsByNid(2, 'en', 'test')
+    );
+    $this->assertEquals(
+      ['node:2', 'taxonomy_term:2'],
+      $this->cacheTagNodeMapper->getCacheTagsByNid(1, 'nl', 'test')
+    );
+    $this->assertEquals(
+      ['node:3', 'taxonomy_term:3'],
+      $this->cacheTagNodeMapper->getCacheTagsByNid(1, 'en', 'test1')
+    );
+  }
+
+  /**
+   * @covers ::getNidsByCacheTag
+   */
+  public function testGetNidsByCacheTag() {
+    $this->assertEquals(
+      [1],
+      $this->cacheTagNodeMapper->getNidsByCacheTag('node:1', 'en', 'test')
+    );
+    $this->assertEquals(
+      [1],
+      $this->cacheTagNodeMapper->getNidsByCacheTag('node:2', 'nl', 'test')
+    );
+    $this->assertEquals(
+      [1],
+      $this->cacheTagNodeMapper->getNidsByCacheTag('node:3', 'en', 'test1')
+    );
+    $this->assertEquals(
+      [2],
+      $this->cacheTagNodeMapper->getNidsByCacheTag('node:4', 'en', 'test')
+    );
+    $this->assertEquals(
+      [1],
+      $this->cacheTagNodeMapper->getNidsByCacheTag('taxonomy_term:1', 'en', 'test')
+    );
+    $this->assertEquals(
+      [1],
+      $this->cacheTagNodeMapper->getNidsByCacheTag('taxonomy_term:2', 'nl', 'test')
+    );
+    $this->assertEquals(
+      [1],
+      $this->cacheTagNodeMapper->getNidsByCacheTag('taxonomy_term:3', 'en', 'test1')
+    );
+    $this->assertEquals(
+      [2],
+      $this->cacheTagNodeMapper->getNidsByCacheTag('taxonomy_term:4', 'en', 'test')
+    );
+  }
+
+  /**
+   * @covers ::delete
+   */
+  public function testDelete() {
+    $this->cacheTagNodeMapper->add([
+      ['node:5', 5, 'en', 'test'],
+      ['node:6', 6, 'en', 'test'],
+      ['node:7', 6, 'en', 'test'],
+      ['node:8', 8, 'en', 'test'],
+      ['node:8', 9, 'en', 'test'],
+      ['node:8', 9, 'en', 'test1'],
+    ]);
+
+    // Single cache tag.
+    $cache_tags = ['node:5'];
+    $this->assertEquals(
+      $cache_tags,
+      $this->cacheTagNodeMapper->getCacheTagsByNid(5, 'en', 'test')
+    );
+    $this->cacheTagNodeMapper->delete($cache_tags, 'en');
+    $this->assertEmpty($this->cacheTagNodeMapper->getCacheTagsByNid(5, 'en', 'test'));
+
+    // Multiple cache tags.
+    $cache_tags = ['node:6', 'node:7'];
+    $this->assertEquals(
+      $cache_tags,
+      $this->cacheTagNodeMapper->getCacheTagsByNid(6, 'en', 'test')
+    );
+    $this->cacheTagNodeMapper->delete($cache_tags, 'en');
+    $this->assertEmpty($this->cacheTagNodeMapper->getCacheTagsByNid(5, 'en', 'test'));
+
+    // Single cache tag + specific nid.
+    $cache_tags = ['node:8'];
+    $this->assertEquals(
+      $cache_tags,
+      $this->cacheTagNodeMapper->getCacheTagsByNid(8, 'en', 'test')
+    );
+    $this->cacheTagNodeMapper->delete($cache_tags, 'en', 8);
+    $this->assertEmpty($this->cacheTagNodeMapper->getCacheTagsByNid(8, 'en', 'test'));
+
+    // Single cache tag + specific nid and next site.
+    $cache_tags = ['node:8'];
+    $this->assertEquals(
+      $cache_tags,
+      $this->cacheTagNodeMapper->getCacheTagsByNid(9, 'en', 'test1')
+    );
+    $this->cacheTagNodeMapper->delete($cache_tags, 'en', 9, 'test1');
+    $this->assertEmpty($this->cacheTagNodeMapper->getCacheTagsByNid(8, 'en', 'test1'));
+  }
+
+}

--- a/modules/next/tests/src/Kernel/CacheTagRevalidatorTaskStoreTest.php
+++ b/modules/next/tests/src/Kernel/CacheTagRevalidatorTaskStoreTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\Tests\next\Kernel\Plugin;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\next\CacheTagRevalidatorTaskStoreInterface;
+
+/**
+ * Tests the cache tag revalidator task store service.
+ *
+ * @coversDefaultClass \Drupal\next\CacheTagRevalidatorTaskStore
+ *
+ * @group next
+ */
+class CacheTagRevalidatorTaskStoreTest extends KernelTestBase {
+
+  /**
+   * The cache tag task store service.
+   *
+   * @var \Drupal\next\CacheTagRevalidatorTaskStoreInterface
+   */
+  protected $taskStore;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'next',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installSchema('next', [
+      CacheTagRevalidatorTaskStoreInterface::TABLE,
+    ]);
+
+    $this->taskStore = $this->container->get('next.cache_tag_revalidator_task_store');
+  }
+
+  /**
+   * @covers ::set
+   * @covers ::has
+   * @covers ::delete
+   */
+  public function testTaskStore() {
+    $this->taskStore->set([1, 2, 3], 'en', 'test');
+
+    $this->assertTrue($this->taskStore->has(1, 'en', 'test'));
+    $this->assertFalse($this->taskStore->has(1, 'nl', 'test'));
+    $this->assertFalse($this->taskStore->has(1, 'en', 'test1'));
+    $this->assertFalse($this->taskStore->has(4, 'en', 'test'));
+
+    $this->taskStore->delete([1, 2], 'en', 'test');
+    $this->assertFalse($this->taskStore->has(1, 'en', 'test'));
+    $this->assertFalse($this->taskStore->has(2, 'en', 'test'));
+    $this->assertTrue($this->taskStore->has(3, 'en', 'test'));
+  }
+
+}


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #763
