### PR TITLE
fix: remove Drupal 11 deprecations from module tests

### DIFF
--- a/modules/next/modules/next_jsonapi/tests/src/Kernel/Controller/EntityResourceTest.php
+++ b/modules/next/modules/next_jsonapi/tests/src/Kernel/Controller/EntityResourceTest.php
@@ -45,7 +45,6 @@ class EntityResourceTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     $this->installConfig(['filter', 'next']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
 
     $type = NodeType::create([

--- a/modules/next/tests/src/Kernel/Controller/NextPreviewUrlControllerTest.php
+++ b/modules/next/tests/src/Kernel/Controller/NextPreviewUrlControllerTest.php
@@ -42,7 +42,6 @@ class NextPreviewUrlControllerTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     $this->installConfig(['filter', 'next']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
 
     $this->nextSite = NextSite::create([

--- a/modules/next/tests/src/Kernel/Entity/NextEntityTypeConfigTest.php
+++ b/modules/next/tests/src/Kernel/Entity/NextEntityTypeConfigTest.php
@@ -41,7 +41,6 @@ class NextEntityTypeConfigTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installEntitySchema('path_alias');
     $this->installConfig(['filter']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
   }
 

--- a/modules/next/tests/src/Kernel/Entity/NextSiteTest.php
+++ b/modules/next/tests/src/Kernel/Entity/NextSiteTest.php
@@ -40,7 +40,6 @@ class NextSiteTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     $this->installConfig(['filter', 'next']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
 
     $this->nextSite = NextSite::create([

--- a/modules/next/tests/src/Kernel/Event/EntityActionEventTest.php
+++ b/modules/next/tests/src/Kernel/Event/EntityActionEventTest.php
@@ -40,7 +40,6 @@ class EntityActionEventTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installConfig(['filter', 'next', 'system', 'user']);
     $this->installSchema('dblog', ['watchdog']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
     $this->installSchema('user', ['users_data']);
 

--- a/modules/next/tests/src/Kernel/Event/EntityRevalidatedEventTest.php
+++ b/modules/next/tests/src/Kernel/Event/EntityRevalidatedEventTest.php
@@ -42,7 +42,6 @@ class EntityRevalidatedEventTest extends KernelTestBase {
     $this->installEntitySchema('next_entity_type_config');
     $this->installConfig(['filter', 'next', 'system', 'user']);
     $this->installSchema('dblog', ['watchdog']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
     $this->installSchema('user', ['users_data']);
 

--- a/modules/next/tests/src/Kernel/NextEntityTypeManagerTest.php
+++ b/modules/next/tests/src/Kernel/NextEntityTypeManagerTest.php
@@ -32,7 +32,6 @@ class NextEntityTypeManagerTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     $this->installConfig(['filter', 'next']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
   }
 

--- a/modules/next/tests/src/Kernel/NextSettingsManagerTest.php
+++ b/modules/next/tests/src/Kernel/NextSettingsManagerTest.php
@@ -36,7 +36,6 @@ class NextSettingsManagerTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     $this->installConfig(['filter', 'next']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
 
     $this->nextSettingsManager = $this->container->get('next.settings.manager');

--- a/modules/next/tests/src/Kernel/Plugin/PathRevalidatorTest.php
+++ b/modules/next/tests/src/Kernel/Plugin/PathRevalidatorTest.php
@@ -47,7 +47,6 @@ class PathRevalidatorTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installEntitySchema('path_alias');
     $this->installConfig(['filter']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
   }
 

--- a/modules/next/tests/src/Kernel/Plugin/SimpleOauthPreviewUrlGeneratorTest.php
+++ b/modules/next/tests/src/Kernel/Plugin/SimpleOauthPreviewUrlGeneratorTest.php
@@ -50,7 +50,6 @@ class SimpleOauthPreviewUrlGeneratorTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     $this->installConfig(['filter', 'next']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
 
     $this->nextSettingsManager = $this->container->get('next.settings.manager');

--- a/modules/next/tests/src/Kernel/Plugin/SiteResolverTest.php
+++ b/modules/next/tests/src/Kernel/Plugin/SiteResolverTest.php
@@ -33,7 +33,6 @@ class SiteResolverTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     $this->installConfig(['filter']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
 
     // Create page type.

--- a/modules/next/tests/src/Kernel/Renderer/MainContent/HtmlRendererTest.php
+++ b/modules/next/tests/src/Kernel/Renderer/MainContent/HtmlRendererTest.php
@@ -35,7 +35,6 @@ class HtmlRendererTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     $this->installConfig(['filter', 'next', 'system', 'user']);
-    $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
     $this->installSchema('user', ['users_data']);
 


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #
_Please add a link to the GitHub issue
where this problem is discussed._

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes
Tests no longer install sequences table. This is deprecated in Drupal 11 and was adding noise to module tests.
* see the following change record for more information: https://www.drupal.org/node/3349345
