### PR TITLE
fix: update apply patches documentation

### DIFF
--- a/www/content/tutorials/graphql/apply-patches.mdx
+++ b/www/content/tutorials/graphql/apply-patches.mdx
@@ -5,37 +5,28 @@ weight: 30
 group: Quick Start (GraphQL)
 ---
 
+At the time of this writing, a patch is required in order to use multilingual features such as translation.
+
 <Callout>
 
-In a future release, these patches will NOT be required for using Next.js and GraphQL.
+**Note:** If you're not using multilingual features such as translation, you can skip this step.
 
 </Callout>
 
-At the time of this writing, there are two patches we need to wire everything together.
-
 1. Open your Drupal `composer.json` file.
-2. Add the following patches under `"extra"`.
+2. Add the following patch under `"extra"`.
 
 ```json title=composer.json
 "extra": {
 		// highlight-start
     "patches": {
-        "drupal/subrequests": {
-            "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
-        },
         "drupal/decoupled_router": {
-            "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
+            "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2024-10-22/decoupled_router-3111456-resolve-langcode-issue-78--external-redirects.patch"
         }
     },
 		// highlight-end
 }
 ```
-
-<Callout>
-
-**Note:** If you're not using multilingual features such as translation, you can skip the second patch.
-
-</Callout>
 
 3. Run the following command:
 
@@ -43,7 +34,6 @@ At the time of this writing, there are two patches we need to wire everything to
 composer require cweagans/composer-patches
 ```
 
-You can read more about the patches here:
+You can read more about the patch here:
 
-1. https://www.drupal.org/project/subrequests/issues/3049395
 2. https://www.drupal.org/project/decoupled_router/issues/3111456

--- a/www/content/tutorials/quick-start/apply-patches.mdx
+++ b/www/content/tutorials/quick-start/apply-patches.mdx
@@ -5,31 +5,28 @@ weight: 30
 group: Quick Start
 ---
 
-At the time of this writing, there are two patches we need to wire everything together.
+At the time of this writing, a patch is required in order to use multilingual features such as translation.
+
+<Callout>
+
+**Note:** If you're not using multilingual features such as translation, you can skip this step.
+
+</Callout>
 
 1. Open your Drupal `composer.json` file.
-2. Add the following patches under `"extra"`.
+2. Add the following patch under `"extra"`.
 
 ```json title=composer.json
 "extra": {
 		// highlight-start
     "patches": {
-        "drupal/subrequests": {
-            "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
-        },
         "drupal/decoupled_router": {
-            "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
+            "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2024-10-22/decoupled_router-3111456-resolve-langcode-issue-78--external-redirects.patch"
         }
     },
 		// highlight-end
 }
 ```
-
-<Callout>
-
-**Note:** If you're not using multilingual features such as translation, you can skip the second patch.
-
-</Callout>
 
 3. Run the following command:
 
@@ -37,7 +34,6 @@ At the time of this writing, there are two patches we need to wire everything to
 composer require cweagans/composer-patches
 ```
 
-You can read more about the patches here:
+You can read more about the patch here:
 
-1. https://www.drupal.org/project/subrequests/issues/3049395
 2. https://www.drupal.org/project/decoupled_router/issues/3111456


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [X] Other

## Describe your changes

This PR updates the apply patches entries in the documentation. The patches were no longer applying, and the subrequests patch should no longer be needed.
