### PR TITLE
docs(next-drupal): update patches docs

### DIFF
--- a/www/content/tutorials/graphql/apply-patches.mdx
+++ b/www/content/tutorials/graphql/apply-patches.mdx
@@ -24,7 +24,7 @@ At the time of this writing, there are two patches we need to wire everything to
             "#3049395-47 - Page Cache causes different subrequests to return the same responses": "https://www.drupal.org/files/issues/2022-12-06/subrequests-3049395-chnage-request-type-47.patch"
         },
         "drupal/decoupled_router": {
-            "#3111456-59 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-12-01/decouple_router-3111456-resolve-language-issue-58--get-translation.patch"
+            "#3111456-63 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2024-07-11/decouple_router-3111456-resolve-language-issue-63--get-translation-re-rolled.patch"
         }
     },
 		// highlight-end

--- a/www/content/tutorials/quick-start/apply-patches.mdx
+++ b/www/content/tutorials/quick-start/apply-patches.mdx
@@ -18,7 +18,7 @@ At the time of this writing, there are two patches we need to wire everything to
             "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
         },
         "drupal/decoupled_router": {
-            "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-11-30/decouple_router-3111456-resolve-language-issue-58.patch"
+            "#3111456-63 - Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2024-07-11/decouple_router-3111456-resolve-language-issue-63--get-translation-re-rolled.patch"
         }
     },
 		// highlight-end


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [X] Other

GitHub Issue: #
https://github.com/chapter-three/next-drupal/issues/789

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

This pull request includes updates to patch references in two tutorial files to ensure they point to the latest versions of the patches for decoupled router. The latest version that gets installed by default needs a new patch so this might make it easier for new users to have a seamless experience trying out the project.

Updates to patch references:

* [`www/content/tutorials/graphql/apply-patches.mdx`](diffhunk://#diff-288834bf1b23cd44ca81b62b172414e7db8d215b5d1558dca956d8c11a882c70L27-R27): Updated the patch reference for `#3111456-59` to `#3111456-63` for resolving path issues in non-default languages.
* [`www/content/tutorials/quick-start/apply-patches.mdx`](diffhunk://#diff-01b9d409d4717f90c5ab27b16fb21380d90356f555779fe015e1f080602821b6L21-R21): Updated the patch reference for resolving path issues in non-default languages to the latest version `#3111456-63`.