### PR TITLE
fix: ignore local environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log*
 /drupal/web/phpunit.xml
 /drupal/web/sites/default/settings.local.php
 /drupal-*
+/local-next-drupal


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [X ] Other

## Describe your changes

Ignored /local-next-drupal - this is a work in progress local environment. Want to ensure that git working area is clean for package publishing.