### PR TITLE
fix: resolve type error in app router slug template

### DIFF
--- a/starters/basic-starter/app/[...slug]/page.tsx
+++ b/starters/basic-starter/app/[...slug]/page.tsx
@@ -59,7 +59,7 @@ type NodePageParams = {
   slug: string[]
 }
 type NodePageProps = {
-  params: NodePageParams
+  params: Promise<NodePageParams>
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }
 


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [x] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

## Describe your changes

This pull request includes a change to the `NodePageProps` type in the `starters/basic-starter/app/[...slug]/page.tsx` file. The change modifies the type of the `params` property from `NodePageParams` to `Promise<NodePageParams>`.

* `starters/basic-starter/app/[...slug]/page.tsx`: Changed the `params` property type in `NodePageProps` from `NodePageParams` to `Promise<NodePageParams>`. ([starters/basic-starter/app/[...slug]/page.tsxL62-R62](diffhunk://#diff-40e122ab26eb8d0eb598cfda52d4793bfc59b7472cb095e260a6dbc397b70089L62-R62))

This was causing a build error in the current canary starter.
