### PR TITLE
fix: make authentication optional in basic and pages starters

### DIFF
--- a/starters/basic-starter/lib/drupal.ts
+++ b/starters/basic-starter/lib/drupal.ts
@@ -5,9 +5,10 @@ const clientId = process.env.DRUPAL_CLIENT_ID as string
 const clientSecret = process.env.DRUPAL_CLIENT_SECRET as string
 
 export const drupal = new NextDrupal(baseUrl, {
-  auth: {
-    clientId,
-    clientSecret,
-  },
+  // Enable to use authentication
+  // auth: {
+  //   clientId,
+  //   clientSecret,
+  // },
   // debug: true,
 })

--- a/starters/basic-starter/lib/drupal.ts
+++ b/starters/basic-starter/lib/drupal.ts
@@ -10,5 +10,6 @@ export const drupal = new NextDrupal(baseUrl, {
   //   clientId,
   //   clientSecret,
   // },
+  // withAuth: true,
   // debug: true,
 })

--- a/starters/pages-starter/lib/drupal.ts
+++ b/starters/pages-starter/lib/drupal.ts
@@ -5,10 +5,11 @@ const clientId = process.env.DRUPAL_CLIENT_ID as string
 const clientSecret = process.env.DRUPAL_CLIENT_SECRET as string
 
 export const drupal = new NextDrupalPages(baseUrl, {
-  auth: {
-    clientId,
-    clientSecret,
-  },
+  // Enable to use authentication
+  // auth: {
+  //   clientId,
+  //   clientSecret,
+  // },
   useDefaultEndpoints: true,
   // debug: true,
 })

--- a/starters/pages-starter/lib/drupal.ts
+++ b/starters/pages-starter/lib/drupal.ts
@@ -10,6 +10,7 @@ export const drupal = new NextDrupalPages(baseUrl, {
   //   clientId,
   //   clientSecret,
   // },
+  // withAuth: true,
   useDefaultEndpoints: true,
   // debug: true,
 })


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ x] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ x] `starters/pages-starter`
- [ ] Other

## Describe your changes

This pull request includes changes to the Drupal client configuration in two files to disable authentication by commenting out the related code blocks. This simplifies the setup for environments where authentication is not required. It also aligns better with our quick start docs which do not address authentication until the draft mode section of the quick start.

Changes to client configuration:

* [`starters/basic-starter/lib/drupal.ts`](diffhunk://#diff-49a273955f5a02b5f382c8f98eb155514b58d03ab3903215e3c6c3b00ebd862aL8-R12): Commented out the `auth` configuration block to disable authentication.
* [`starters/pages-starter/lib/drupal.ts`](diffhunk://#diff-7f59e64cf0146b99567636f542bf5bb51797766e8589c794613d2c0923d8db16L8-R12): Commented out the `auth` configuration block to disable authentication.