### PR TITLE
build: fix bug in starter sync script that was preventing stable release publishing

### DIFF
--- a/scripts/sync-repo.sh
+++ b/scripts/sync-repo.sh
@@ -25,7 +25,7 @@ for folder in $GLOB; do
   CLONE_DIR="__${NAME}__clone__"
 
   # Note: redirect output to dev/null to avoid any possibility of leaking token
-  git clone --quiet --depth 1 --branch ${BRANCH} ${REPO}${NAME}.git $CLONE_DIR > /dev/null
+  git clone --quiet --branch ${BRANCH} ${REPO}${NAME}.git $CLONE_DIR > /dev/null
   cd $CLONE_DIR
 
   # Delete all files (to handle deletions in monorepo)


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ x] Other

## Describe your changes

This pull request includes a small change to the `scripts/sync-repo.sh` file. The change removes the `--depth 1` option from the `git clone` command to ensure that the full history is cloned rather than just the latest commit.

* [`scripts/sync-repo.sh`](diffhunk://#diff-2568406177f99891dd19cc5114ec3d7adb1a230bc85ea945973cade26ffc5269L28-R28): Removed `--depth 1` from the `git clone` command to clone the full repository history.
