### PR TITLE
docs(building-pages): use 'type' instead of 'path' in getResource fun…

### DIFF
--- a/www/content/docs/pages.mdx
+++ b/www/content/docs/pages.mdx
@@ -138,7 +138,7 @@ export default function Page({ params }) {
     params.addFields("node--article", ["title", "path", "body", "uid"])
   }
 
-  const node = await drupal.getResource(path, path.entity.uuid {
+  const node = await drupal.getResource(type, path.entity.uuid {
     params: params.getQueryObject(),
   })
 
@@ -190,7 +190,7 @@ export default function Page({ params }) {
     params.addFields("node--article", ["title", "path", "body", "uid"])
   }
 
-  const node = await drupal.getResource(path, path.entity.uuid {
+  const node = await drupal.getResource(type, path.entity.uuid {
     params: params.getQueryObject(),
     tags: [tag]
   })


### PR DESCRIPTION
…ction

This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [X] Other

GitHub Issue: #841 

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Description  

In the *building pages* documentation, the `drupal.getResource` function was being called with the result of `drupal.translatePath` as its first parameter. However, this is incorrect because `getResource` requires the entity type as its first argument.  

I've updated the documentation by replacing these calls with the correct entity type. The type is already stored in a constant:  

```javascript
const type = path.jsonapi.resourceName;

Now, `getResource` calls use this type as the first parameter.

