### PR TITLE
Issue 843: Revalidate node path alias instead of node/#

### DIFF
--- a/modules/next/src/Event/EntityActionEvent.php
+++ b/modules/next/src/Event/EntityActionEvent.php
@@ -4,6 +4,7 @@ namespace Drupal\next\Event;
 
 use Drupal\Component\EventDispatcher\Event;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
 
 /**
  * Defines an entity action event.
@@ -36,9 +37,9 @@ class EntityActionEvent extends Event implements EntityActionEventInterface {
   /**
    * The entity Url.
    *
-   * @var string|null
+   * @var \Drupal\Core\Url|null
    */
-  protected ?string $entityUrl;
+  protected ?Url $entityUrl;
 
   /**
    * EntityActionEvent constructor.
@@ -49,10 +50,10 @@ class EntityActionEvent extends Event implements EntityActionEventInterface {
    *   The action.
    * @param array $sites
    *   The sites for the entity.
-   * @param string|null $entity_url
+   * @param \Drupal\Core\Url|null $entity_url
    *   The entity url.
    */
-  public function __construct(EntityInterface $entity, string $action, array $sites, ?string $entity_url) {
+  public function __construct(EntityInterface $entity, string $action, array $sites, ?Url $entity_url) {
     $this->entity = $entity;
     $this->action = $action;
     $this->sites = $sites;
@@ -75,12 +76,7 @@ class EntityActionEvent extends Event implements EntityActionEventInterface {
     $next_entity_type_manager = \Drupal::service('next.entity_type.manager');
 
     $sites = $next_entity_type_manager->getSitesForEntity($entity);
-    try {
-      $url = $entity->hasLinkTemplate('canonical') ? $entity->toUrl()->toString(TRUE)->getGeneratedUrl() : NULL;
-    }
-    catch (\Exception $e) {
-      $url = NULL;
-    }
+    $url = $entity->hasLinkTemplate('canonical') ? $entity->toUrl() : NULL;
     return new static($entity, $action, $sites, $url);
   }
 
@@ -132,14 +128,14 @@ class EntityActionEvent extends Event implements EntityActionEventInterface {
   /**
    * {@inheritdoc}
    */
-  public function getEntityUrl(): ?string {
+  public function getEntityUrl(): ?Url {
     return $this->entityUrl;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function setEntityUrl(string $url): EntityActionEventInterface {
+  public function setEntityUrl(Url $url): EntityActionEventInterface {
     $this->entityUrl = $url;
     return $this;
   }

--- a/modules/next/src/Event/EntityActionEventInterface.php
+++ b/modules/next/src/Event/EntityActionEventInterface.php
@@ -3,6 +3,7 @@
 namespace Drupal\next\Event;
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
 
 /**
  * Defines an interface for entity action events.
@@ -86,20 +87,20 @@ interface EntityActionEventInterface {
   /**
    * Gets the url for the entity.
    *
-   * @return string|null
+   * @return \Drupal\Core\Url|null
    *   The entity url.
    */
-  public function getEntityUrl(): ?string;
+  public function getEntityUrl(): ?Url;
 
   /**
    * Sets the url for the entity.
    *
-   * @param string $url
+   * @param \Drupal\Core\Url $url
    *   The entity url.
    *
    * @return \Drupal\next\Event\EntityActionEventInterface
    *   The event entity.
    */
-  public function setEntityUrl(string $url): self;
+  public function setEntityUrl(Url $url): self;
 
 }

--- a/modules/next/src/Plugin/Next/Revalidator/Path.php
+++ b/modules/next/src/Plugin/Next/Revalidator/Path.php
@@ -73,7 +73,7 @@ class Path extends ConfigurableRevalidatorBase implements RevalidatorInterface {
 
     $paths = [];
     if (!empty($this->configuration['revalidate_page'])) {
-      $paths[] = $event->getEntityUrl();
+      $paths[] = $event->getEntityUrl()->toString(TRUE)->getGeneratedUrl();
     }
     if (!empty($this->configuration['additional_paths'])) {
       $paths = array_merge($paths, array_map('trim', explode("\n", $this->configuration['additional_paths'])));


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [X ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #843
_Please add a link to the GitHub issue
where this problem is discussed._

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes
Refactor the parameter on the event to use the url object so that the path alias is revalidated on node insert.

If applicable, add screenshots to help explain your issue.
