### PR TITLE
fix(next): Allow ajax callback inside of NextEntityTypeConfigForm to be executed

### DIFF
--- a/modules/next/src/Form/NextEntityTypeConfigForm.php
+++ b/modules/next/src/Form/NextEntityTypeConfigForm.php
@@ -103,7 +103,6 @@ class NextEntityTypeConfigForm extends EntityForm {
       '#ajax' => [
         'callback' => '::ajaxReplaceSettingsForm',
         'wrapper' => 'settings-container',
-        'method' => 'replace',
       ],
     ];
 
@@ -138,7 +137,6 @@ class NextEntityTypeConfigForm extends EntityForm {
         '#ajax' => [
           'callback' => '::ajaxReplaceSiteResolverSettingsForm',
           'wrapper' => 'site-resolver-settings',
-          'method' => 'replace',
         ],
       ];
 


### PR DESCRIPTION
Allow ajax callback inside of NextEntityTypeConfigForm to be executed

Fixes #845

This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #
[https://github.com/chapter-three/next-drupal/issues/845](https://github.com/chapter-three/next-drupal/issues/845)

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

Removed the "replace" method so that the ajax callbacks are working again and you can select the relevant options (for example the site for editing the Draft mode)
