### PR TITLE
Send host header to Decoupled Router.

### DIFF
--- a/packages/next-drupal/src/next-drupal.ts
+++ b/packages/next-drupal/src/next-drupal.ts
@@ -3,6 +3,7 @@ import { stringify } from "qs"
 import { JsonApiErrors } from "./jsonapi-errors"
 import { DrupalMenuTree } from "./menu-tree"
 import { NextDrupalBase } from "./next-drupal-base"
+import { headers } from 'next/headers'
 import type {
   BaseUrl,
   DrupalFile,
@@ -927,8 +928,12 @@ export class NextDrupal extends NextDrupalBase {
       ...options,
     }
 
+    const headersList = await headers();
+    const host = headersList.get('host')?.replace(/:\d+$/, '') || '';
+
     const endpoint = this.buildUrl("/router/translate-path", {
       path,
+      host,
     }).toString()
 
     this.debug(`Fetching translated path, ${path}.`)


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [x] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #332
_Please add a link to the GitHub issue
where this problem is discussed._

- [x] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

This is an alternative to the suggestion in #332, instead of needing different Drupal base URLs we pass on the host header from the original request as a query parameter to Decoupled Router. I also have an extended version of Decoupled Router that interprets that query parameter and passes it to Domain module, allowing decoupled multi-domain setups with a single Drupal backend URL.
