### PR TITLE
fix: preview mode by using the node canonical routes

### DIFF
--- a/modules/next/src/NextEntityTypeManager.php
+++ b/modules/next/src/NextEntityTypeManager.php
@@ -66,14 +66,22 @@ class NextEntityTypeManager implements NextEntityTypeManagerInterface {
     $entity_types_ids = $this->getConfigEntityTypeIds();
 
     // @todo Handle all revisionable entity types.
-    $revision_routes = ['entity.node.revision', 'entity.node.latest_version'];
+    $revision_routes = [
+      'entity.node.canonical',
+      'entity.node.revision',
+      'entity.node.latest_version',
+    ];
+
     if (in_array($route_match->getRouteName(), $revision_routes) && in_array('node', $entity_types_ids)) {
       $node_revision = $route_match->getParameter('node_revision');
       if ($node_revision instanceof NodeInterface) {
         return $node_revision;
       }
 
-      if ($route_match->getRouteName() === 'entity.node.latest_version') {
+      if (
+        $route_match->getRouteName() === 'entity.node.latest_version' ||
+        $route_match->getRouteName() === 'entity.node.canonical'
+      ) {
         $node_revision = $route_match->getParameter('node')->getRevisionId();
       }
 


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #
#857

## Describe your changes

Allow the canonical to be used for the Headless Iframe view.
