### PR TITLE
fix: show live link for revisions

### DIFF
--- a/modules/next/src/Plugin/Next/SitePreviewer/Iframe.php
+++ b/modules/next/src/Plugin/Next/SitePreviewer/Iframe.php
@@ -221,7 +221,6 @@ class Iframe extends ConfigurableSitePreviewerBase implements ContainerFactoryPl
         ]),
         'attributes' => [],
       ];
-      unset($build['toolbar']['links']['#links']['live_link']);
     }
 
     $build['iframe'] = [


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue #859 

## Describe your changes

Show the live_link button for revisions.

I've also added a patch that you can add to the composer.json of your project:

[show-live-link.patch](https://github.com/user-attachments/files/20911262/show-live-link.patch)

