### PR TITLE
fix(next-drupal): handle archived content responses for path translation

### DIFF
--- a/packages/next-drupal/src/next-drupal.ts
+++ b/packages/next-drupal/src/next-drupal.ts
@@ -939,7 +939,7 @@ export class NextDrupal extends NextDrupalBase {
       cache: options.cache,
     })
 
-    if (response.status === 404) {
+    if (response.status === 404 || response.status === 403) {
       // Do not throw errors here, otherwise Next.js will catch the error and
       // throw a 500. We want a 404.
       return null


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [x] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #864 


- [x] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

Similar to 404 responses when translating paths, a 403 response needs to be handled.
