### PR TITLE
Update the endpoint for getMenu

### DIFF
--- a/packages/next-drupal/src/next-drupal.ts
+++ b/packages/next-drupal/src/next-drupal.ts
@@ -1108,8 +1108,7 @@ export class NextDrupal extends NextDrupalBase {
     const endpoint = await this.buildEndpoint({
       locale:
         options?.locale !== options?.defaultLocale ? options.locale : undefined,
-      resourceType: "menu_items",
-      path: menuName,
+      path: `/menu_items/${menuName}`,
       searchParams: options.params,
     })
 


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [x] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #752

## Describe your changes

As described in the related issue, menu_items is not an entity and therefore is not exposed in the /jsonapi index.
Instead of creating a menu_items endpoint as a resource type, build the endpoint using its path.