### PR TITLE
feat(#875): add workspace id to preview query

### DIFF
--- a/modules/next/src/Entity/NextSite.php
+++ b/modules/next/src/Entity/NextSite.php
@@ -245,6 +245,15 @@ class NextSite extends ConfigEntityBase implements NextSiteInterface {
       $query['resourceVersion'] = $resource_version;
     }
 
+    // Add workspace information if available
+    if (\Drupal::moduleHandler()->moduleExists('workspaces')) {
+      $workspace_manager = \Drupal::service('workspaces.manager');
+      $active_workspace = $workspace_manager->getActiveWorkspace();
+      if ($active_workspace) {
+        $query['workspace'] = $active_workspace->id();
+      }
+    }
+
     $preview_url->setOption('query', $query);
 
     return $preview_url;


### PR DESCRIPTION
This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #875
_Please add a link to the GitHub issue
where this problem is discussed._

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

Adds the workspace ID to the site preview querystring if applicable
