### PR TITLE
Fix PHP 8.4 incompatibility

### DIFF
--- a/modules/next/modules/next_jwt/src/Plugin/Next/PreviewUrlGenerator/Jwt.php
+++ b/modules/next/modules/next_jwt/src/Plugin/Next/PreviewUrlGenerator/Jwt.php
@@ -132,7 +132,7 @@ class Jwt extends ConfigurablePreviewUrlGeneratorBase {
   /**
    * {@inheritdoc}
    */
-  public function generate(NextSiteInterface $next_site, EntityInterface $entity, string $resource_version = NULL): ?Url {
+  public function generate(NextSiteInterface $next_site, EntityInterface $entity, ?string $resource_version = NULL): ?Url {
     $query = [];
     $query['path'] = $path = $entity->toUrl()->toString();
     $query['uuid'] = $this->user->uuid();

--- a/modules/next/src/Form/IframeSitePreviewerSwitcherForm.php
+++ b/modules/next/src/Form/IframeSitePreviewerSwitcherForm.php
@@ -47,7 +47,7 @@ class IframeSitePreviewerSwitcherForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, EntityInterface $entity = NULL, array $sites = [], string $site_id = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, ?EntityInterface $entity = NULL, array $sites = [], ?string $site_id = NULL) {
     /** @var \Drupal\next\Entity\NextSiteInterface[] $sites */
     $site_options = [];
     foreach ($sites as $site) {

--- a/modules/next/src/Form/NextEntityTypeConfigForm.php
+++ b/modules/next/src/Form/NextEntityTypeConfigForm.php
@@ -60,7 +60,7 @@ class NextEntityTypeConfigForm extends EntityForm {
    * @param \Drupal\next\Plugin\RevalidatorManagerInterface $revalidator_manager
    *   The revalidator manager.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, SiteResolverManagerInterface $site_resolver_manager, RevalidatorManagerInterface $revalidator_manager = NULL) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, SiteResolverManagerInterface $site_resolver_manager, ?RevalidatorManagerInterface $revalidator_manager = NULL) {
     if (!$revalidator_manager) {
       @trigger_error('Calling NextEntityTypeConfigForm::__construct() without the $revalidator_manager argument is deprecated in next:1.4.0 and will be required in next:2.0.0. See https://www.drupal.org/node/3325622', E_USER_DEPRECATED);
       // @codingStandardsIgnoreStart

--- a/modules/next/src/Plugin/Next/PreviewUrlGenerator/SimpleOauth.php
+++ b/modules/next/src/Plugin/Next/PreviewUrlGenerator/SimpleOauth.php
@@ -124,7 +124,7 @@ class SimpleOauth extends ConfigurablePreviewUrlGeneratorBase {
   /**
    * {@inheritdoc}
    */
-  public function generate(NextSiteInterface $next_site, EntityInterface $entity, string $resource_version = NULL): ?Url {
+  public function generate(NextSiteInterface $next_site, EntityInterface $entity, ?string $resource_version = NULL): ?Url {
     $query = [];
     $query['path'] = $path = $entity->toUrl()->toString();
 

--- a/modules/next/src/Plugin/PreviewUrlGeneratorInterface.php
+++ b/modules/next/src/Plugin/PreviewUrlGeneratorInterface.php
@@ -49,7 +49,7 @@ interface PreviewUrlGeneratorInterface {
    * @return \Drupal\Core\Url|null
    *   The generated preview url.
    */
-  public function generate(NextSiteInterface $next_site, EntityInterface $entity, string $resource_version = NULL): ?Url;
+  public function generate(NextSiteInterface $next_site, EntityInterface $entity, ?string $resource_version = NULL): ?Url;
 
   /**
    * Validates the preview url.


### PR DESCRIPTION
The module throws some warnings about "Implicitly marking a parameter as nullable is deprecated since PHP 8.4."

This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [x] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #870

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

Adjusts the method signatures regarding implicit nullable parameters to be compatible with PHP 8.4.

Previously submitted as #869, but I accidentally closed that by deleting my fork.