### PR TITLE
fix: use path-specific commit message in sync script

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -26,7 +26,7 @@ While maintaining releases for packages, starters and examples is done with Lern
       "sync:modules": "./scripts/sync-repo.sh 3.x git@git.drupal.org:project/ \"modules/*\"",
       ```
 
-2. Run `yarn sync:modules` to sync the latest commit on `main` with the git repo on drupal.org. All recent changes will be squashed into a commit using the latest commit message.
+2. Run `yarn sync:modules` to sync the latest commit on `main` with the git repo on drupal.org. All recent changes will be squashed into a commit using the most recent commit message that touched the synced path.
 
 3. On Drupal.org’s GitLab, [tag a release](https://git.drupalcode.org/project/next/-/tags/new) following the [“Release tags naming conventions” docs](https://www.drupal.org/docs/develop/git/git-for-drupal-project-maintainers/release-naming-conventions#release-tags).
 
@@ -131,7 +131,7 @@ The code in the examples repos do not strictly require a versioned release since
    yarn sync:examples
    ```
 
-   All recent changes on `main` will be squashed into a commit on the target git repo using the latest commit message.
+   All recent changes on `main` will be squashed into a commit on the target git repo using the most recent commit message that touched the synced path.
 
 ### Starters
 
@@ -158,7 +158,7 @@ The code in the examples repos do not strictly require a versioned release since
    yarn sync:starters:release
    ```
 
-   All recent changes on `main` will be squashed into a commit on the target git repo using the latest commit message.
+   All recent changes on `main` will be squashed into a commit on the target git repo using the most recent commit message that touched the synced path.
 
 4. **Create a GitHub release and tag**
 

--- a/scripts/sync-repo.sh
+++ b/scripts/sync-repo.sh
@@ -15,7 +15,10 @@ BRANCH=$(echo $BRANCHES | cut -d "," -f 1)
 TRACKING_BRANCH=$(echo $BRANCHES | cut -d "," -f 2)
 
 BASE=$(pwd)
-COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+COMMIT_MESSAGE=$(git log -1 --pretty=%B -- $GLOB)
+if [ -z "$COMMIT_MESSAGE" ]; then
+  COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+fi
 
 for folder in $GLOB; do
   [ -d "$folder" ] || continue


### PR DESCRIPTION
## Summary

- Sync script now uses the most recent commit that touched the synced path (`modules/*`, `starters/*`, etc.) instead of always using the repo's latest commit
- Falls back to latest commit if no path-specific commit exists
- Updates MAINTAINING.md to reflect the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)