### PR TITLE
fix(ci): tighten PR workflow permissions and secret access (v1.6 backport)

### DIFF
--- a/.github/workflows/next-drupal.yml
+++ b/.github/workflows/next-drupal.yml
@@ -32,7 +32,14 @@ jobs:
         if: github.event_name == 'pull_request'
         run: yarn test packages/next-drupal --testPathIgnorePatterns=crud.test --coverageThreshold='{}'
         env:
+          # Placeholders only — unit tests mock fetch. The test utils
+          # construct a Drupal client at module load and require these
+          # to be present (not valid).
           DRUPAL_BASE_URL: http://localhost
+          DRUPAL_USERNAME: test
+          DRUPAL_PASSWORD: test
+          DRUPAL_CLIENT_ID: test
+          DRUPAL_CLIENT_SECRET: test
       - name: Run all tests (push)
         if: github.event_name == 'push'
         run: yarn test packages/next-drupal

--- a/.github/workflows/next-drupal.yml
+++ b/.github/workflows/next-drupal.yml
@@ -1,19 +1,40 @@
 name: next-drupal
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - v1.6
+  pull_request:
+    branches:
+      - v1.6
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
       - name: Install modules
-        run: yarn
-      - name: Run tests
+        run: yarn install --frozen-lockfile
+      - name: Run unit tests (PR)
+        if: github.event_name == 'pull_request'
+        run: yarn test packages/next-drupal --testPathIgnorePatterns=crud.test --coverageThreshold='{}'
+        env:
+          DRUPAL_BASE_URL: http://localhost
+      - name: Run all tests (push)
+        if: github.event_name == 'push'
         run: yarn test packages/next-drupal
         env:
           DRUPAL_BASE_URL: ${{ secrets.DRUPAL_BASE_URL }}

--- a/.github/workflows/next-drupal.yml
+++ b/.github/workflows/next-drupal.yml
@@ -30,7 +30,9 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Run unit tests (PR)
         if: github.event_name == 'pull_request'
-        run: yarn test packages/next-drupal --testPathIgnorePatterns=crud.test --coverageThreshold='{}'
+        # Skip integration test files that exercise a live Drupal instance.
+        # Tracking removal of the live dependency in .claude/plans/.
+        run: yarn test packages/next-drupal --testPathIgnorePatterns="client.test|crud.test" --coverageThreshold='{}'
         env:
           # Placeholders only — unit tests mock fetch. The test utils
           # construct a Drupal client at module load and require these

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -37,8 +37,8 @@ jobs:
         id: composercache
         run: |
           cd modules/next
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.drupal }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,24 +1,37 @@
 name: release-pr
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   next-drupal:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, format('release-pr{0} next-drupal', ':')) }}
+    timeout-minutes: 15
+    if: |
+      contains(github.event.pull_request.labels.*.name, format('release-pr{0} next-drupal', ':')) &&
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     environment: Preview
     steps:
       - name: Init
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
+          registry-url: https://registry.npmjs.org/
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Determine version
         uses: ./.github/version-pr
         id: determine-version
@@ -27,18 +40,22 @@ jobs:
       - name: Publish to npm
         run: |
           cd packages/next-drupal
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
           yarn publish --no-git-checks --access public --tag experimental
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Comment version on PR
-        uses: NejcZdovc/comment-pr@v2
-        with:
-          message:
-            "🎉 Experimental release [published 📦️ on npm](https://npmjs.com/package/next-drupal/v/${{ env.VERSION }})!\n \
-            ```sh\npnpm add next-drupal@${{ env.VERSION }}\n```\n \
-            ```sh\nyarn add next-drupal@${{ env.VERSION }}\n```\n \
-            ```sh\nnpm i next-drupal@${{ env.VERSION }}\n```"
         env:
           VERSION: ${{ steps.determine-version.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "🎉 Experimental release [published 📦️ on npm](https://npmjs.com/package/next-drupal/v/$VERSION)!
+          \`\`\`sh
+          pnpm add next-drupal@$VERSION
+          \`\`\`
+          \`\`\`sh
+          yarn add next-drupal@$VERSION
+          \`\`\`
+          \`\`\`sh
+          npm i next-drupal@$VERSION
+          \`\`\`"


### PR DESCRIPTION
## Summary

Backport of #901 to the `v1.6` maintenance branch. Applies the same security mitigations to `next-drupal.yml` and `release-pr.yml` so this branch's PR-triggered workflows have the same hardened defaults.

### `next-drupal.yml`
- Switch from `pull_request_target` to `pull_request`
- `persist-credentials: false` on checkout
- `permissions: contents: read` at workflow root
- Drupal secrets only loaded when `github.event_name == 'push'` to `v1.6`
- PR runs skip integration tests that exercise a live Drupal instance (`client.test`, `crud.test`) and lift coverage threshold accordingly
- `concurrency` cancel-in-progress + `timeout-minutes: 15`
- Bump `actions/checkout` and `actions/setup-node` to v4
- Pass placeholder `DRUPAL_*` env vars on PR runs (test utils construct a Drupal client at module load and require these to be present)

### `release-pr.yml`
- Trigger restricted to `pull_request: [labeled]`
- Internal-PR guard: `head.repo.full_name == base.repo.full_name`
- `persist-credentials: false` on checkout
- `setup-node@v4` `registry-url` + `NODE_AUTH_TOKEN` (replaces inline `.npmrc` echo)
- Replace third-party comment action with built-in `gh pr comment`
- `permissions: contents: read, pull-requests: write`
- `concurrency` cancel-in-progress + `timeout-minutes: 15`

### `next.yml`
- Bump `actions/cache@v2` → `v4` (v2 is automatically failed by GitHub) and replace deprecated `::set-output` syntax with `$GITHUB_OUTPUT`

## Test plan

- [x] CI on this PR validates the new `next-drupal.yml` (PR path, integration tests skipped) — `test` job passes
- [ ] Push-to-v1.6 path runs full test suite with Drupal secrets after merge
- [ ] `release-pr.yml` validated on next experimental release attempt against this branch

## Notes

The Drupal phpunit matrix jobs (`Drupal 9.4`, `Drupal 9.5`, `Drupal 10.0`) in `next.yml` show as failing on this PR. Those failures are **pre-existing** — they were already failing on `v1.6` before this PR was opened and are unrelated to the security changes here. The matrix targets Drupal versions that are EOL upstream (Drupal 9.x reached EOL in late 2023; 10.0 reached EOL in late 2023), and the locked `symfony/console` version no longer satisfies current `composer/composer` requirements. Updating that matrix to currently-supported Drupal versions is a separate maintenance task and out of scope for this security fix.

The `next-drupal` `test` job (the workflow this PR actually hardens) passes.