### PR TITLE
docs: document branch model and update supported versions

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -2,6 +2,25 @@
 
 This document is for maintainers to explain the various procedures for all the projects in this monorepo.
 
+## Branch model
+
+This monorepo uses three active branches that serve different roles in the release lifecycle. Each is also wired to a separate Vercel docs deployment.
+
+| Branch | Role | Vercel deployment |
+| ------ | ---- | ----------------- |
+| `main` | Active development for the next major release. New features land here first. | https://next.next-drupal.org/ |
+| `v2.0` | Pre-release staging. Features merge here from `main` once they are release-candidate quality, then are published to npm. | https://next-drupal.org/ |
+| `v1.6` | Older supported version (security and critical fixes only). | https://v1-6.next-drupal.org/ |
+
+Older release branches (`v1`, `v0`) exist for historical reference but are no longer Vercel-deployed and do not receive patches. See `SECURITY.md` for the supported-versions matrix.
+
+### Where to target a PR
+
+- **New feature for the next major release** — open against `main`.
+- **Backport / patch for the current stable line** — open against `v2.0`.
+- **Security or critical fix for the older supported line** — open against `v1.6`.
+- **Docs-only change for a specific version's docs site** — open against the branch whose Vercel deployment you want to update. For general-purpose docs, target `main` and let the release flow propagate.
+
 ## Making releases
 
 ### `next` (Drupal Module)
@@ -181,13 +200,13 @@ The code in the examples repos do not strictly require a versioned release since
 
 ### Docs
 
-@TODO: Expand details the next time docs are deployed.
-
 Documentation is deployed to Vercel and controlled via the following Git branches:
 
-- `v1.6`
-- `v1`
-- `v0`
+- `main` → https://next.next-drupal.org/
+- `v2.0` → https://next-drupal.org/
+- `v1.6` → https://v1-6.next-drupal.org/
+
+Each branch's Vercel project auto-deploys on push.
 
 ## Tests
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,7 @@ Refer to the table below for versions supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 2.x.x   | :white_check_mark: |
 | 1.x.x   | :white_check_mark: |
 | < 1.0.0 | :x:                |
 
@@ -15,6 +16,7 @@ Refer to the table below for versions supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 2.x.x   | :white_check_mark: |
 | 1.x.x   | :white_check_mark: |
 | < 1.0.0 | :x:                |
 


### PR DESCRIPTION
## Summary

Documents the active-branch model and corrects two stale sections of project docs.

### `MAINTAINING.md`
- New top-level **Branch model** section describing the roles of `main`, `v2.0`, and `v1.6`, the Vercel docs subdomain each one drives, and where contributors should target PRs based on change type.
- Replaces the stale "Docs" deployment list (which referenced `v1.6`, `v1`, `v0`) with the current `main` / `v2.0` / `v1.6` → subdomain mapping. Removes the `@TODO` marker since the details are now filled in.

### `SECURITY.md`
- Adds `2.x.x` to the supported-versions table for both `next-drupal` and the `next` Drupal module. The current stable npm release is `2.0.1`, so 2.x is the active line; 1.x remains supported on the `v1.6` branch.

## Test plan

- [ ] Markdown renders cleanly on GitHub
- [ ] Links to https://next.next-drupal.org/, https://next-drupal.org/, https://v1-6.next-drupal.org/ resolve

## Notes

The `next` Drupal module versioning is assumed to follow the same 1.x/2.x split as the npm package. If the contrib module's release line differs, update that table accordingly.